### PR TITLE
feat: add normalized domain model spec and schema (issue #11)

### DIFF
--- a/docs/spec/normalized-domain-model.md
+++ b/docs/spec/normalized-domain-model.md
@@ -1,0 +1,44 @@
+# Normalized Domain Model v1
+
+This document defines the normalized model required by issue `#11`.
+
+## Design Goals
+
+- Represent all supported client formats without lossy conversion.
+- Keep model boundaries clear across `Client`, `MCP`, and `Skill`.
+- Expose explicit extension points for future attributes.
+- Keep source traceability (`origin/path/line/column/warnings`) for every normalized entity.
+
+## Entity Boundaries
+
+1. `Client`
+- Runtime detection status and capabilities.
+- No MCP/Skill payload fields embedded directly.
+
+2. `MCP`
+- Runtime configuration details for tool servers.
+- Transport and environment fields are isolated in dedicated sub-objects.
+
+3. `Skill`
+- Installation target and metadata independent from MCP transport details.
+
+## Lossless Mapping Strategy
+
+- Every normalized entity includes:
+  - `source`: where the normalized item came from
+  - `raw`: provider/client-specific original fields
+- `raw` ensures that unsupported vendor fields can be retained without changing the normalized schema.
+
+## Extension Points
+
+- Every entity includes `extensions: {}` for forward-compatible attributes.
+- Extensions are intentionally unconstrained to avoid schema churn when new clients are added.
+
+## Files
+
+- Schema:
+  - `schemas/normalized-domain-model.schema.json`
+- Canonical sample:
+  - `docs/spec/normalized-domain-model.v1.json`
+- Unit tests:
+  - `tests/normalized-domain-model.test.mjs`

--- a/docs/spec/normalized-domain-model.v1.json
+++ b/docs/spec/normalized-domain-model.v1.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "../../schemas/normalized-domain-model.schema.json",
+  "version": "1.0.0",
+  "updatedAt": "2026-02-26",
+  "entities": {
+    "clients": [
+      {
+        "id": "client:claude_code:default",
+        "clientType": "claude_code",
+        "displayName": "Claude Code",
+        "status": "detected",
+        "capabilities": {
+          "supportsMcp": true,
+          "supportsSkills": true,
+          "supportsEnableDisable": true
+        },
+        "source": {
+          "origin": "detector",
+          "path": "~/.claude/claude_code_config.json",
+          "warnings": []
+        },
+        "raw": {
+          "detectorVersion": "v1"
+        },
+        "extensions": {
+          "futureClientMetadata": {}
+        }
+      },
+      {
+        "id": "client:cursor:default",
+        "clientType": "cursor",
+        "displayName": "Cursor",
+        "status": "partial",
+        "capabilities": {
+          "supportsMcp": true,
+          "supportsSkills": true,
+          "supportsEnableDisable": false
+        },
+        "source": {
+          "origin": "detector",
+          "path": "~/.cursor/mcp.json",
+          "warnings": [
+            "binary_unresolved"
+          ]
+        },
+        "raw": {
+          "appDataRoot": "~/.cursor"
+        },
+        "extensions": {
+          "futureClientMetadata": {}
+        }
+      }
+    ],
+    "mcps": [
+      {
+        "id": "mcp:claude_code:filesystem",
+        "clientId": "client:claude_code:default",
+        "name": "filesystem",
+        "enabled": true,
+        "transport": {
+          "kind": "stdio",
+          "command": "npx",
+          "args": [
+            "-y",
+            "@modelcontextprotocol/server-filesystem",
+            "/Users/fengliu/Code"
+          ]
+        },
+        "env": [
+          {
+            "key": "API_KEY",
+            "valueRef": "${OPENAI_API_KEY}",
+            "isSecret": true
+          }
+        ],
+        "source": {
+          "origin": "mcp_config",
+          "path": "~/.claude/claude_code_config.json",
+          "line": 18,
+          "column": 9,
+          "warnings": []
+        },
+        "raw": {
+          "providerSpecific": {
+            "timeoutMs": 12000
+          }
+        },
+        "extensions": {
+          "futureTransportMetadata": {}
+        }
+      }
+    ],
+    "skills": [
+      {
+        "id": "skill:cursor:python-refactor",
+        "clientId": "client:cursor:default",
+        "name": "python-refactor",
+        "enabled": true,
+        "install": {
+          "kind": "file",
+          "path": "~/.cursor/skills/python-refactor/SKILL.md"
+        },
+        "metadata": {
+          "description": "Refactor Python code with safety checks",
+          "version": "1.2.0",
+          "tags": [
+            "python",
+            "refactor"
+          ]
+        },
+        "source": {
+          "origin": "skills_dir",
+          "path": "~/.cursor/skills/python-refactor/SKILL.md",
+          "warnings": []
+        },
+        "raw": {
+          "manifest": {
+            "author": "internal"
+          }
+        },
+        "extensions": {
+          "futureSkillMetadata": {}
+        }
+      }
+    ]
+  }
+}

--- a/schemas/normalized-domain-model.schema.json
+++ b/schemas/normalized-domain-model.schema.json
@@ -1,0 +1,345 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://thundermiracle.github.io/ai-manager/schemas/normalized-domain-model.schema.json",
+  "title": "AI Manager Normalized Domain Model",
+  "type": "object",
+  "required": [
+    "version",
+    "updatedAt",
+    "entities"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "updatedAt": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "entities": {
+      "type": "object",
+      "required": [
+        "clients",
+        "mcps",
+        "skills"
+      ],
+      "properties": {
+        "clients": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/client"
+          }
+        },
+        "mcps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/mcp"
+          }
+        },
+        "skills": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/skill"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "sourceMetadata": {
+      "type": "object",
+      "required": [
+        "origin",
+        "path"
+      ],
+      "properties": {
+        "origin": {
+          "type": "string",
+          "enum": [
+            "detector",
+            "mcp_config",
+            "skills_dir"
+          ]
+        },
+        "path": {
+          "type": "string"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "column": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "client": {
+      "type": "object",
+      "required": [
+        "id",
+        "clientType",
+        "displayName",
+        "status",
+        "capabilities",
+        "source",
+        "extensions"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "clientType": {
+          "type": "string",
+          "enum": [
+            "claude_code",
+            "codex_cli",
+            "cursor",
+            "codex_app"
+          ]
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "detected",
+            "partial",
+            "absent",
+            "error"
+          ]
+        },
+        "capabilities": {
+          "type": "object",
+          "required": [
+            "supportsMcp",
+            "supportsSkills",
+            "supportsEnableDisable"
+          ],
+          "properties": {
+            "supportsMcp": {
+              "type": "boolean"
+            },
+            "supportsSkills": {
+              "type": "boolean"
+            },
+            "supportsEnableDisable": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "source": {
+          "$ref": "#/$defs/sourceMetadata"
+        },
+        "raw": {
+          "type": "object"
+        },
+        "extensions": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    "mcpTransport": {
+      "type": "object",
+      "required": [
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "stdio",
+            "http",
+            "sse",
+            "streamable_http"
+          ]
+        },
+        "command": {
+          "type": "string"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "url": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "mcpEnvVar": {
+      "type": "object",
+      "required": [
+        "key",
+        "isSecret"
+      ],
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "valueRef": {
+          "type": "string"
+        },
+        "isSecret": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "mcp": {
+      "type": "object",
+      "required": [
+        "id",
+        "clientId",
+        "name",
+        "enabled",
+        "transport",
+        "env",
+        "source",
+        "extensions"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "transport": {
+          "$ref": "#/$defs/mcpTransport"
+        },
+        "env": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/mcpEnvVar"
+          }
+        },
+        "source": {
+          "$ref": "#/$defs/sourceMetadata"
+        },
+        "raw": {
+          "type": "object"
+        },
+        "extensions": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    "skillInstall": {
+      "type": "object",
+      "required": [
+        "kind",
+        "path"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "file",
+            "directory",
+            "reference"
+          ]
+        },
+        "path": {
+          "type": "string"
+        },
+        "sourceUrl": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "skill": {
+      "type": "object",
+      "required": [
+        "id",
+        "clientId",
+        "name",
+        "enabled",
+        "install",
+        "metadata",
+        "source",
+        "extensions"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "install": {
+          "$ref": "#/$defs/skillInstall"
+        },
+        "metadata": {
+          "type": "object",
+          "required": [
+            "tags"
+          ],
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "source": {
+          "$ref": "#/$defs/sourceMetadata"
+        },
+        "raw": {
+          "type": "object"
+        },
+        "extensions": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/normalized-domain-model.test.mjs
+++ b/tests/normalized-domain-model.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+const modelPath = new URL("../docs/spec/normalized-domain-model.v1.json", import.meta.url);
+const model = JSON.parse(readFileSync(modelPath, "utf8"));
+
+const clientTypeSet = new Set(["claude_code", "codex_cli", "cursor", "codex_app"]);
+const transportKindSet = new Set(["stdio", "http", "sse", "streamable_http"]);
+const skillInstallKindSet = new Set(["file", "directory", "reference"]);
+
+test("domain model envelope version and entity groups are present", () => {
+  assert.equal(model.version, "1.0.0");
+  assert.ok(model.entities);
+  assert.ok(Array.isArray(model.entities.clients));
+  assert.ok(Array.isArray(model.entities.mcps));
+  assert.ok(Array.isArray(model.entities.skills));
+});
+
+test("client entities expose capability flags and extension points", () => {
+  for (const client of model.entities.clients) {
+    assert.ok(clientTypeSet.has(client.clientType), `unsupported client type: ${client.clientType}`);
+    assert.equal(typeof client.capabilities.supportsMcp, "boolean");
+    assert.equal(typeof client.capabilities.supportsSkills, "boolean");
+    assert.equal(typeof client.capabilities.supportsEnableDisable, "boolean");
+    assert.equal(typeof client.extensions, "object");
+    assert.equal(typeof client.raw, "object");
+  }
+});
+
+test("mcp entities include transport model, source metadata and raw payload", () => {
+  for (const mcp of model.entities.mcps) {
+    assert.ok(transportKindSet.has(mcp.transport.kind), `unsupported transport: ${mcp.transport.kind}`);
+    assert.equal(typeof mcp.source.origin, "string");
+    assert.equal(typeof mcp.source.path, "string");
+    assert.equal(typeof mcp.extensions, "object");
+    assert.equal(typeof mcp.raw, "object");
+    assert.ok(Array.isArray(mcp.env));
+  }
+});
+
+test("skill entities include install model, metadata and raw payload", () => {
+  for (const skill of model.entities.skills) {
+    assert.ok(
+      skillInstallKindSet.has(skill.install.kind),
+      `unsupported install kind: ${skill.install.kind}`,
+    );
+    assert.equal(typeof skill.install.path, "string");
+    assert.ok(Array.isArray(skill.metadata.tags));
+    assert.equal(typeof skill.source.path, "string");
+    assert.equal(typeof skill.extensions, "object");
+    assert.equal(typeof skill.raw, "object");
+  }
+});
+
+test("cross-entity references are consistent", () => {
+  const clientIds = new Set(model.entities.clients.map((client) => client.id));
+
+  for (const mcp of model.entities.mcps) {
+    assert.ok(clientIds.has(mcp.clientId), `mcp references unknown client: ${mcp.clientId}`);
+  }
+
+  for (const skill of model.entities.skills) {
+    assert.ok(clientIds.has(skill.clientId), `skill references unknown client: ${skill.clientId}`);
+  }
+});


### PR DESCRIPTION
## Summary
- add normalized domain model JSON schema (`schemas/normalized-domain-model.schema.json`)
- add versioned domain model spec (`docs/spec/normalized-domain-model.v1.json`)
- add human-readable model documentation (`docs/spec/normalized-domain-model.md`)
- add unit tests for schema/document consistency (`tests/normalized-domain-model.test.mjs`)

## Why
Implements Issue #11 by defining the canonical data model for AI clients, skills, and MCP entries in a stable, testable contract.

## Validation
- `pnpm test`

Closes #11