### PR TITLE
feat: add parser framework and fixture corpus (#21)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,3 +22,4 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "1"

--- a/src-tauri/fixtures/parsers/claude_code.valid.json
+++ b/src-tauri/fixtures/parsers/claude_code.valid.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "enabled": true
+    },
+    "github": {
+      "url": "https://mcp.example.com/sse",
+      "enabled": false
+    }
+  }
+}

--- a/src-tauri/fixtures/parsers/codex_app.valid.json
+++ b/src-tauri/fixtures/parsers/codex_app.valid.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "notion": {
+      "url": "https://codex-app.example.com/sse",
+      "enabled": true
+    }
+  }
+}

--- a/src-tauri/fixtures/parsers/codex_cli.valid.toml
+++ b/src-tauri/fixtures/parsers/codex_cli.valid.toml
@@ -1,0 +1,7 @@
+[mcp_servers.filesystem]
+command = "npx"
+enabled = true
+
+[mcp_servers.github]
+url = "https://mcp.example.com/sse"
+enabled = false

--- a/src-tauri/fixtures/parsers/cursor.valid.json
+++ b/src-tauri/fixtures/parsers/cursor.valid.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "context7"
+    },
+    "invalid_entry": "skip-me"
+  }
+}

--- a/src-tauri/fixtures/parsers/index.json
+++ b/src-tauri/fixtures/parsers/index.json
@@ -1,0 +1,74 @@
+[
+  {
+    "name": "claude_code_valid_json",
+    "client": "claude_code",
+    "fixture": "claude_code.valid.json",
+    "expected": "success",
+    "min_servers": 2,
+    "warning_codes": [],
+    "error_codes": []
+  },
+  {
+    "name": "cursor_valid_json_with_warning",
+    "client": "cursor",
+    "fixture": "cursor.valid.json",
+    "expected": "success",
+    "min_servers": 1,
+    "warning_codes": ["PARSER_SERVER_ENTRY_INVALID"],
+    "error_codes": []
+  },
+  {
+    "name": "codex_app_valid_json",
+    "client": "codex_app",
+    "fixture": "codex_app.valid.json",
+    "expected": "success",
+    "min_servers": 1,
+    "warning_codes": [],
+    "error_codes": []
+  },
+  {
+    "name": "codex_cli_valid_toml",
+    "client": "codex_cli",
+    "fixture": "codex_cli.valid.toml",
+    "expected": "success",
+    "min_servers": 2,
+    "warning_codes": [],
+    "error_codes": []
+  },
+  {
+    "name": "json_missing_section",
+    "client": "claude_code",
+    "fixture": "missing_section.json",
+    "expected": "success",
+    "min_servers": 0,
+    "warning_codes": ["PARSER_MCP_SECTION_MISSING"],
+    "error_codes": []
+  },
+  {
+    "name": "toml_missing_section",
+    "client": "codex_cli",
+    "fixture": "missing_section.toml",
+    "expected": "success",
+    "min_servers": 0,
+    "warning_codes": ["PARSER_MCP_SECTION_MISSING"],
+    "error_codes": []
+  },
+  {
+    "name": "malformed_json",
+    "client": "cursor",
+    "fixture": "malformed.json",
+    "expected": "failure",
+    "min_servers": 0,
+    "warning_codes": [],
+    "error_codes": ["PARSER_JSON_SYNTAX"]
+  },
+  {
+    "name": "malformed_toml",
+    "client": "codex_cli",
+    "fixture": "malformed.toml",
+    "expected": "failure",
+    "min_servers": 0,
+    "warning_codes": [],
+    "error_codes": ["PARSER_TOML_SYNTAX"]
+  }
+]

--- a/src-tauri/fixtures/parsers/malformed.json
+++ b/src-tauri/fixtures/parsers/malformed.json
@@ -1,0 +1,5 @@
+{
+  "mcpServers": {
+    "broken": {
+      "command": "npx"
+    }

--- a/src-tauri/fixtures/parsers/malformed.toml
+++ b/src-tauri/fixtures/parsers/malformed.toml
@@ -1,0 +1,2 @@
+[mcp_servers.filesystem
+command = "npx"

--- a/src-tauri/fixtures/parsers/missing_section.json
+++ b/src-tauri/fixtures/parsers/missing_section.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "description": "no mcp section"
+}

--- a/src-tauri/fixtures/parsers/missing_section.toml
+++ b/src-tauri/fixtures/parsers/missing_section.toml
@@ -1,0 +1,2 @@
+version = 1
+name = "missing mcp section"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod contracts;
 mod detection;
 mod domain;
 mod infra;
+pub mod parsers;
 mod state;
 
 use commands::{detect_clients, list_resources, mutate_resource};

--- a/src-tauri/src/parsers/client_config_parser.rs
+++ b/src-tauri/src/parsers/client_config_parser.rs
@@ -1,0 +1,8 @@
+use crate::contracts::common::ClientKind;
+
+use super::{ParseOutcome, ParsedClientConfig};
+
+pub trait ClientConfigParser: Send + Sync {
+    fn client_kind(&self) -> ClientKind;
+    fn parse(&self, source: &str) -> ParseOutcome<ParsedClientConfig>;
+}

--- a/src-tauri/src/parsers/fixture_tests.rs
+++ b/src-tauri/src/parsers/fixture_tests.rs
@@ -1,0 +1,157 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::Deserialize;
+
+use crate::contracts::common::ClientKind;
+
+use super::{ParseOutcome, ParserRegistry};
+
+#[derive(Debug, Deserialize)]
+struct FixtureCase {
+    name: String,
+    client: String,
+    fixture: String,
+    expected: String,
+    min_servers: usize,
+    warning_codes: Vec<String>,
+    error_codes: Vec<String>,
+}
+
+#[test]
+fn parser_registry_matches_fixture_expectations() {
+    let fixtures_root = fixtures_root();
+    let fixture_cases = load_fixture_cases(&fixtures_root);
+    let registry = ParserRegistry::new();
+
+    for case in fixture_cases {
+        let client = parse_client_kind(&case.client);
+        let source_path = fixtures_root.join(&case.fixture);
+        let source = fs::read_to_string(&source_path).unwrap_or_else(|error| {
+            panic!(
+                "failed to read fixture '{}': {error}",
+                source_path.display()
+            )
+        });
+
+        let expected_warning_codes = sorted_codes(case.warning_codes.clone());
+        let expected_error_codes = sorted_codes(case.error_codes.clone());
+
+        match registry.parse_client_config(client, &source) {
+            ParseOutcome::Success { data, warnings } => {
+                assert_eq!(
+                    case.expected, "success",
+                    "fixture '{}' expected a failure but parser returned success",
+                    case.name
+                );
+                assert_eq!(data.client, client, "fixture '{}'", case.name);
+                assert_eq!(
+                    data.format,
+                    expected_format(client),
+                    "fixture '{}'",
+                    case.name
+                );
+                assert!(
+                    data.mcp_servers.len() >= case.min_servers,
+                    "fixture '{}' expected at least {} servers, got {}",
+                    case.name,
+                    case.min_servers,
+                    data.mcp_servers.len()
+                );
+
+                let actual_warning_codes =
+                    sorted_codes(warnings.into_iter().map(|warning| warning.code.to_string()));
+                assert_eq!(
+                    actual_warning_codes, expected_warning_codes,
+                    "fixture '{}' warning code mismatch",
+                    case.name
+                );
+                assert!(
+                    expected_error_codes.is_empty(),
+                    "fixture '{}' expected error codes {:?} but parser returned success",
+                    case.name,
+                    expected_error_codes
+                );
+            }
+            ParseOutcome::Failure { warnings, errors } => {
+                let warning_messages: Vec<String> = warnings
+                    .iter()
+                    .map(|warning| format!("{}: {}", warning.code, warning.message))
+                    .collect();
+                let error_messages: Vec<String> = errors
+                    .iter()
+                    .map(|error| format!("{}: {}", error.code, error.message))
+                    .collect();
+                let actual_warning_codes =
+                    sorted_codes(warnings.into_iter().map(|warning| warning.code.to_string()));
+                let actual_error_codes =
+                    sorted_codes(errors.into_iter().map(|error| error.code.to_string()));
+                assert_eq!(
+                    case.expected, "failure",
+                    "fixture '{}' expected success but parser returned failure (warnings: {:?}, errors: {:?})",
+                    case.name, warning_messages, error_messages
+                );
+
+                assert_eq!(
+                    actual_warning_codes, expected_warning_codes,
+                    "fixture '{}' warning code mismatch",
+                    case.name
+                );
+                assert_eq!(
+                    actual_error_codes, expected_error_codes,
+                    "fixture '{}' error code mismatch",
+                    case.name
+                );
+            }
+        }
+    }
+}
+
+fn fixtures_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/parsers")
+}
+
+fn load_fixture_cases(fixtures_root: &Path) -> Vec<FixtureCase> {
+    let index_path = fixtures_root.join("index.json");
+    let index_payload = fs::read_to_string(&index_path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read fixture index '{}': {error}",
+            index_path.display()
+        )
+    });
+
+    serde_json::from_str::<Vec<FixtureCase>>(&index_payload).unwrap_or_else(|error| {
+        panic!(
+            "failed to parse fixture index '{}': {error}",
+            index_path.display()
+        )
+    })
+}
+
+fn parse_client_kind(value: &str) -> ClientKind {
+    match value {
+        "claude_code" => ClientKind::ClaudeCode,
+        "codex_cli" => ClientKind::CodexCli,
+        "cursor" => ClientKind::Cursor,
+        "codex_app" => ClientKind::CodexApp,
+        other => panic!("unsupported client kind in fixture index: {other}"),
+    }
+}
+
+fn expected_format(client: ClientKind) -> &'static str {
+    match client {
+        ClientKind::CodexCli => "toml",
+        ClientKind::ClaudeCode | ClientKind::Cursor | ClientKind::CodexApp => "json",
+    }
+}
+
+fn sorted_codes<I>(codes: I) -> Vec<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut normalized: Vec<String> = codes.into_iter().collect();
+    normalized.sort_unstable();
+    normalized
+}

--- a/src-tauri/src/parsers/json_parser.rs
+++ b/src-tauri/src/parsers/json_parser.rs
@@ -1,0 +1,131 @@
+use serde_json::Value;
+
+use crate::contracts::common::ClientKind;
+
+use super::{
+    ClientConfigParser, ParseError, ParseOutcome, ParseWarning, ParsedClientConfig, ParsedMcpServer,
+};
+
+pub struct JsonClientConfigParser {
+    client_kind: ClientKind,
+}
+
+impl JsonClientConfigParser {
+    pub fn new(client_kind: ClientKind) -> Self {
+        Self { client_kind }
+    }
+}
+
+impl ClientConfigParser for JsonClientConfigParser {
+    fn client_kind(&self) -> ClientKind {
+        self.client_kind
+    }
+
+    fn parse(&self, source: &str) -> ParseOutcome<ParsedClientConfig> {
+        let parsed_value = match serde_json::from_str::<Value>(source) {
+            Ok(value) => value,
+            Err(error) => {
+                return ParseOutcome::Failure {
+                    warnings: Vec::new(),
+                    errors: vec![ParseError {
+                        code: "PARSER_JSON_SYNTAX",
+                        message: format!("Invalid JSON payload: {error}"),
+                    }],
+                };
+            }
+        };
+
+        let mut warnings: Vec<ParseWarning> = Vec::new();
+        let mut servers: Vec<ParsedMcpServer> = Vec::new();
+
+        let mcp_servers = parsed_value
+            .get("mcpServers")
+            .or_else(|| parsed_value.get("mcp_servers"));
+
+        let Some(mcp_servers) = mcp_servers else {
+            warnings.push(ParseWarning {
+                code: "PARSER_MCP_SECTION_MISSING",
+                message: "No MCP section (`mcpServers` or `mcp_servers`) was found.".to_string(),
+            });
+
+            return ParseOutcome::Success {
+                data: ParsedClientConfig {
+                    client: self.client_kind,
+                    format: "json",
+                    mcp_servers: servers,
+                },
+                warnings,
+            };
+        };
+
+        let Some(mcp_server_map) = mcp_servers.as_object() else {
+            warnings.push(ParseWarning {
+                code: "PARSER_MCP_SECTION_INVALID",
+                message: "MCP section exists but is not an object map.".to_string(),
+            });
+
+            return ParseOutcome::Success {
+                data: ParsedClientConfig {
+                    client: self.client_kind,
+                    format: "json",
+                    mcp_servers: servers,
+                },
+                warnings,
+            };
+        };
+
+        for (server_name, server_payload) in mcp_server_map {
+            let Some(server_object) = server_payload.as_object() else {
+                warnings.push(ParseWarning {
+                    code: "PARSER_SERVER_ENTRY_INVALID",
+                    message: format!(
+                        "Server `{server_name}` entry is not an object and was skipped."
+                    ),
+                });
+                continue;
+            };
+
+            let transport_kind = if server_object
+                .get("command")
+                .and_then(Value::as_str)
+                .is_some()
+            {
+                Some("stdio")
+            } else if server_object.get("url").and_then(Value::as_str).is_some() {
+                Some("sse")
+            } else {
+                None
+            };
+
+            let Some(transport_kind) = transport_kind else {
+                warnings.push(ParseWarning {
+                    code: "PARSER_SERVER_TRANSPORT_MISSING",
+                    message: format!(
+                        "Server `{server_name}` has no supported transport fields (`command` or `url`)."
+                    ),
+                });
+                continue;
+            };
+
+            let enabled = server_object
+                .get("enabled")
+                .and_then(Value::as_bool)
+                .unwrap_or(true);
+
+            servers.push(ParsedMcpServer {
+                name: server_name.to_string(),
+                transport_kind: transport_kind.to_string(),
+                enabled,
+            });
+        }
+
+        ParseOutcome::Success {
+            data: ParsedClientConfig {
+                client: self.client_kind,
+                format: "json",
+                mcp_servers: servers,
+            },
+            warnings,
+        }
+    }
+}

--- a/src-tauri/src/parsers/mod.rs
+++ b/src-tauri/src/parsers/mod.rs
@@ -1,0 +1,11 @@
+mod client_config_parser;
+#[cfg(test)]
+mod fixture_tests;
+mod json_parser;
+mod registry;
+mod toml_parser;
+mod types;
+
+pub use client_config_parser::ClientConfigParser;
+pub use registry::ParserRegistry;
+pub use types::{ParseError, ParseOutcome, ParseWarning, ParsedClientConfig, ParsedMcpServer};

--- a/src-tauri/src/parsers/registry.rs
+++ b/src-tauri/src/parsers/registry.rs
@@ -1,0 +1,53 @@
+use crate::contracts::common::ClientKind;
+
+use super::{
+    ClientConfigParser, ParseError, ParseOutcome, ParsedClientConfig,
+    json_parser::JsonClientConfigParser, toml_parser::TomlClientConfigParser,
+};
+
+pub struct ParserRegistry;
+
+impl ParserRegistry {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn parse_client_config(
+        &self,
+        client_kind: ClientKind,
+        source: &str,
+    ) -> ParseOutcome<ParsedClientConfig> {
+        let parser = self.parser_for_client(client_kind);
+
+        if parser.client_kind() != client_kind {
+            return ParseOutcome::Failure {
+                warnings: Vec::new(),
+                errors: vec![ParseError {
+                    code: "PARSER_CLIENT_MISMATCH",
+                    message: format!(
+                        "Parser client mismatch: expected '{}', parser returned '{}'.",
+                        client_kind.as_str(),
+                        parser.client_kind().as_str()
+                    ),
+                }],
+            };
+        }
+
+        parser.parse(source)
+    }
+
+    fn parser_for_client(&self, client_kind: ClientKind) -> Box<dyn ClientConfigParser> {
+        match client_kind {
+            ClientKind::CodexCli => Box::new(TomlClientConfigParser::new(client_kind)),
+            ClientKind::ClaudeCode | ClientKind::Cursor | ClientKind::CodexApp => {
+                Box::new(JsonClientConfigParser::new(client_kind))
+            }
+        }
+    }
+}
+
+impl Default for ParserRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src-tauri/src/parsers/toml_parser.rs
+++ b/src-tauri/src/parsers/toml_parser.rs
@@ -1,0 +1,133 @@
+use crate::contracts::common::ClientKind;
+
+use super::{
+    ClientConfigParser, ParseError, ParseOutcome, ParseWarning, ParsedClientConfig, ParsedMcpServer,
+};
+
+pub struct TomlClientConfigParser {
+    client_kind: ClientKind,
+}
+
+impl TomlClientConfigParser {
+    pub fn new(client_kind: ClientKind) -> Self {
+        Self { client_kind }
+    }
+}
+
+impl ClientConfigParser for TomlClientConfigParser {
+    fn client_kind(&self) -> ClientKind {
+        self.client_kind
+    }
+
+    fn parse(&self, source: &str) -> ParseOutcome<ParsedClientConfig> {
+        let parsed_table = match toml::from_str::<toml::Table>(source) {
+            Ok(table) => table,
+            Err(error) => {
+                return ParseOutcome::Failure {
+                    warnings: Vec::new(),
+                    errors: vec![ParseError {
+                        code: "PARSER_TOML_SYNTAX",
+                        message: format!("Invalid TOML payload: {error}"),
+                    }],
+                };
+            }
+        };
+
+        let mut warnings: Vec<ParseWarning> = Vec::new();
+        let mut servers: Vec<ParsedMcpServer> = Vec::new();
+
+        let mcp_servers = parsed_table
+            .get("mcp_servers")
+            .or_else(|| parsed_table.get("mcpServers"));
+
+        let Some(mcp_servers) = mcp_servers else {
+            warnings.push(ParseWarning {
+                code: "PARSER_MCP_SECTION_MISSING",
+                message: "No MCP section (`mcp_servers` or `mcpServers`) was found.".to_string(),
+            });
+
+            return ParseOutcome::Success {
+                data: ParsedClientConfig {
+                    client: self.client_kind,
+                    format: "toml",
+                    mcp_servers: servers,
+                },
+                warnings,
+            };
+        };
+
+        let Some(mcp_server_map) = mcp_servers.as_table() else {
+            warnings.push(ParseWarning {
+                code: "PARSER_MCP_SECTION_INVALID",
+                message: "MCP section exists but is not a table map.".to_string(),
+            });
+
+            return ParseOutcome::Success {
+                data: ParsedClientConfig {
+                    client: self.client_kind,
+                    format: "toml",
+                    mcp_servers: servers,
+                },
+                warnings,
+            };
+        };
+
+        for (server_name, server_payload) in mcp_server_map {
+            let Some(server_table) = server_payload.as_table() else {
+                warnings.push(ParseWarning {
+                    code: "PARSER_SERVER_ENTRY_INVALID",
+                    message: format!(
+                        "Server `{server_name}` entry is not a table and was skipped."
+                    ),
+                });
+                continue;
+            };
+
+            let transport_kind = if server_table
+                .get("command")
+                .and_then(toml::Value::as_str)
+                .is_some()
+            {
+                Some("stdio")
+            } else if server_table
+                .get("url")
+                .and_then(toml::Value::as_str)
+                .is_some()
+            {
+                Some("sse")
+            } else {
+                None
+            };
+
+            let Some(transport_kind) = transport_kind else {
+                warnings.push(ParseWarning {
+                    code: "PARSER_SERVER_TRANSPORT_MISSING",
+                    message: format!(
+                        "Server `{server_name}` has no supported transport fields (`command` or `url`)."
+                    ),
+                });
+                continue;
+            };
+
+            let enabled = server_table
+                .get("enabled")
+                .and_then(toml::Value::as_bool)
+                .unwrap_or(true);
+
+            servers.push(ParsedMcpServer {
+                name: server_name.to_string(),
+                transport_kind: transport_kind.to_string(),
+                enabled,
+            });
+        }
+
+        ParseOutcome::Success {
+            data: ParsedClientConfig {
+                client: self.client_kind,
+                format: "toml",
+                mcp_servers: servers,
+            },
+            warnings,
+        }
+    }
+}

--- a/src-tauri/src/parsers/types.rs
+++ b/src-tauri/src/parsers/types.rs
@@ -1,0 +1,48 @@
+use crate::contracts::common::ClientKind;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseWarning {
+    pub code: &'static str,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedMcpServer {
+    pub name: String,
+    pub transport_kind: String,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedClientConfig {
+    pub client: ClientKind,
+    pub format: &'static str,
+    pub mcp_servers: Vec<ParsedMcpServer>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseOutcome<T> {
+    Success {
+        data: T,
+        warnings: Vec<ParseWarning>,
+    },
+    Failure {
+        warnings: Vec<ParseWarning>,
+        errors: Vec<ParseError>,
+    },
+}
+
+impl<T> ParseOutcome<T> {
+    pub fn warnings(&self) -> &[ParseWarning] {
+        match self {
+            Self::Success { warnings, .. } => warnings,
+            Self::Failure { warnings, .. } => warnings,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new parser module with `ClientConfigParser` trait, parse outcome model, and registry keyed by `ClientKind`
- implement JSON and TOML parsers with deterministic MCP normalization (`stdio`/`sse`) and explicit warning/error codes
- add a fixture corpus (`src-tauri/fixtures/parsers`) and index-driven unit test to validate success/failure expectations and warning/error separation
- expose parser module from crate root for downstream integration

## Testing
- `pnpm run lint`
- `pnpm test`
- `cargo test --manifest-path src-tauri/Cargo.toml`

Closes #21