### PR TITLE
feat: add backup/atomic-write/rollback mutation infrastructure (#24)

### DIFF
--- a/src-tauri/src/application/adapter_service.rs
+++ b/src-tauri/src/application/adapter_service.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use crate::{
     application::{
         mcp_listing_service::McpListingService, skill_listing_service::SkillListingService,
@@ -10,7 +12,7 @@ use crate::{
         mutate::{MutateResourceRequest, MutateResourceResponse},
     },
     detection::DetectorRegistry,
-    infra::AdapterRegistry,
+    infra::{AdapterRegistry, MutationTestHooks, SafeFileMutator},
 };
 
 pub struct AdapterService<'a> {
@@ -92,6 +94,45 @@ impl<'a> AdapterService<'a> {
             ));
         }
 
+        let file_mutation_payload = parse_file_mutation_payload(request.payload.as_ref())?;
+        if let Some(file_mutation_payload) = file_mutation_payload {
+            let target_path = Path::new(&file_mutation_payload.target_path);
+            let new_content = file_mutation_payload.content.as_bytes();
+            let mutator = SafeFileMutator::new();
+
+            let outcome = if file_mutation_payload.fail_after_write {
+                let hooks = MutationTestHooks {
+                    fail_after_backup: false,
+                    fail_after_write: true,
+                };
+
+                mutator.replace_file_with_hooks(target_path, new_content, hooks)
+            } else {
+                mutator.replace_file(target_path, new_content)
+            }
+            .map_err(|failure| {
+                CommandError::internal(format!(
+                    "[stage={:?}] {} (rollback_succeeded={})",
+                    failure.stage, failure.message, failure.rollback_succeeded
+                ))
+            })?;
+
+            let mut message = format!(
+                "Applied safe mutation to '{}'.",
+                file_mutation_payload.target_path
+            );
+            if let Some(backup_path) = outcome.backup_path {
+                message.push_str(&format!(" Backup: {}.", backup_path));
+            }
+
+            return Ok(MutateResourceResponse {
+                accepted: true,
+                action: request.action,
+                target_id: target_id.to_string(),
+                message,
+            });
+        }
+
         let Some(adapter) = self.adapter_registry.find(request.client) else {
             return Err(CommandError::internal(format!(
                 "No adapter registered for '{}'.",
@@ -110,8 +151,62 @@ impl<'a> AdapterService<'a> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileMutationPayload {
+    target_path: String,
+    content: String,
+    fail_after_write: bool,
+}
+
+fn parse_file_mutation_payload(
+    payload: Option<&serde_json::Value>,
+) -> Result<Option<FileMutationPayload>, CommandError> {
+    let Some(payload) = payload else {
+        return Ok(None);
+    };
+
+    let maybe_target_path = payload
+        .get("target_path")
+        .and_then(serde_json::Value::as_str);
+    let maybe_content = payload.get("content").and_then(serde_json::Value::as_str);
+    let fail_after_write = payload
+        .get("fail_after_write")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    if maybe_target_path.is_none() && maybe_content.is_none() {
+        return Ok(None);
+    }
+
+    let Some(target_path) = maybe_target_path else {
+        return Err(CommandError::validation(
+            "payload.target_path must be a non-empty string when file mutation payload is provided.",
+        ));
+    };
+    let Some(content) = maybe_content else {
+        return Err(CommandError::validation(
+            "payload.content must be a string when file mutation payload is provided.",
+        ));
+    };
+
+    let target_path = target_path.trim();
+    if target_path.is_empty() {
+        return Err(CommandError::validation(
+            "payload.target_path must not be empty when file mutation payload is provided.",
+        ));
+    }
+
+    Ok(Some(FileMutationPayload {
+        target_path: target_path.to_string(),
+        content: content.to_string(),
+        fail_after_write,
+    }))
+}
+
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use super::AdapterService;
     use crate::{
         contracts::{
@@ -123,6 +218,7 @@ mod tests {
         detection::DetectorRegistry,
         infra::AdapterRegistry,
     };
+    use serde_json::json;
 
     #[test]
     fn detect_clients_uses_every_registered_detector() {
@@ -199,5 +295,75 @@ mod tests {
             .expect_err("blank target_id should fail validation");
 
         assert!(error.message.contains("target_id"));
+    }
+
+    #[test]
+    fn mutate_resource_applies_safe_file_mutation_when_payload_matches_contract() {
+        let adapter_registry = AdapterRegistry::with_default_adapters();
+        let detector_registry = DetectorRegistry::with_default_detectors();
+        let service = AdapterService::new(&adapter_registry, &detector_registry);
+
+        let temp_dir = std::env::temp_dir().join(format!(
+            "ai-manager-mutate-safe-payload-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&temp_dir);
+        let target = temp_dir.join("mcp.json");
+        fs::write(&target, "{\"before\":true}").expect("should create mutation target");
+
+        let response = service
+            .mutate_resource(&MutateResourceRequest {
+                client: ClientKind::Cursor,
+                resource_kind: ResourceKind::Mcp,
+                action: MutationAction::Add,
+                target_id: "cursor-mcp".to_string(),
+                payload: Some(json!({
+                    "target_path": target.display().to_string(),
+                    "content": "{\"before\":false}"
+                })),
+            })
+            .expect("safe file mutation payload should succeed");
+
+        let content = fs::read_to_string(&target).expect("should read mutated target");
+        let _ = fs::remove_dir_all(&temp_dir);
+
+        assert!(response.accepted);
+        assert_eq!(content, "{\"before\":false}");
+        assert!(response.message.contains("Applied safe mutation"));
+    }
+
+    #[test]
+    fn mutate_resource_rolls_back_file_when_post_write_failure_is_requested() {
+        let adapter_registry = AdapterRegistry::with_default_adapters();
+        let detector_registry = DetectorRegistry::with_default_detectors();
+        let service = AdapterService::new(&adapter_registry, &detector_registry);
+
+        let temp_dir = std::env::temp_dir().join(format!(
+            "ai-manager-mutate-safe-rollback-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&temp_dir);
+        let target = temp_dir.join("mcp.json");
+        fs::write(&target, "{\"before\":true}").expect("should create mutation target");
+
+        let error = service
+            .mutate_resource(&MutateResourceRequest {
+                client: ClientKind::Cursor,
+                resource_kind: ResourceKind::Mcp,
+                action: MutationAction::Add,
+                target_id: "cursor-mcp".to_string(),
+                payload: Some(json!({
+                    "target_path": target.display().to_string(),
+                    "content": "{\"before\":false}",
+                    "fail_after_write": true
+                })),
+            })
+            .expect_err("post-write failure should surface command error");
+
+        let content = fs::read_to_string(&target).expect("should read rolled back target");
+        let _ = fs::remove_dir_all(&temp_dir);
+
+        assert!(error.message.contains("rollback_succeeded=true"));
+        assert_eq!(content, "{\"before\":true}");
     }
 }

--- a/src-tauri/src/infra/mod.rs
+++ b/src-tauri/src/infra/mod.rs
@@ -1,3 +1,5 @@
 mod adapter_registry;
+mod mutation;
 
 pub use adapter_registry::AdapterRegistry;
+pub use mutation::{MutationTestHooks, SafeFileMutator};

--- a/src-tauri/src/infra/mutation/atomic_writer.rs
+++ b/src-tauri/src/infra/mutation/atomic_writer.rs
@@ -1,0 +1,99 @@
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+pub struct AtomicWriter;
+
+impl AtomicWriter {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn replace_file(&self, target_path: &Path, new_content: &[u8]) -> std::io::Result<()> {
+        let temp_path = build_temp_path(target_path)?;
+        let parent = target_path.parent().ok_or_else(|| {
+            std::io::Error::other(format!(
+                "target path '{}' has no parent directory",
+                target_path.display()
+            ))
+        })?;
+        fs::create_dir_all(parent)?;
+
+        {
+            let mut file = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temp_path)?;
+            file.write_all(new_content)?;
+            file.sync_all()?;
+        }
+
+        if let Err(error) = fs::rename(&temp_path, target_path) {
+            let _ = fs::remove_file(&temp_path);
+            return Err(error);
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for AtomicWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn build_temp_path(target_path: &Path) -> std::io::Result<PathBuf> {
+    let parent = target_path.parent().ok_or_else(|| {
+        std::io::Error::other(format!(
+            "target path '{}' has no parent directory",
+            target_path.display()
+        ))
+    })?;
+
+    let filename = target_path
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .unwrap_or_else(|| "target".to_string());
+
+    let timestamp_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(std::io::Error::other)?
+        .as_nanos();
+
+    Ok(parent.join(format!(
+        ".{}.{}.{}.tmp",
+        filename,
+        std::process::id(),
+        timestamp_nanos
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::AtomicWriter;
+
+    #[test]
+    fn replace_file_updates_target_content_atomically() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("ai-manager-atomic-write-{}", std::process::id()));
+        let _ = fs::create_dir_all(&temp_dir);
+
+        let target = temp_dir.join("config.toml");
+        fs::write(&target, "enabled = false").expect("should create initial target");
+
+        AtomicWriter::new()
+            .replace_file(&target, b"enabled = true")
+            .expect("atomic replace should succeed");
+
+        let content = fs::read_to_string(&target).expect("should read replaced target");
+        let _ = fs::remove_dir_all(&temp_dir);
+
+        assert_eq!(content, "enabled = true");
+    }
+}

--- a/src-tauri/src/infra/mutation/backup_manager.rs
+++ b/src-tauri/src/infra/mutation/backup_manager.rs
@@ -1,0 +1,128 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackupArtifact {
+    pub backup_path: Option<PathBuf>,
+    pub target_existed: bool,
+}
+
+pub struct BackupManager;
+
+impl BackupManager {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn create_backup(&self, target_path: &Path) -> std::io::Result<BackupArtifact> {
+        if !target_path.exists() {
+            return Ok(BackupArtifact {
+                backup_path: None,
+                target_existed: false,
+            });
+        }
+
+        if !target_path.is_file() {
+            return Err(std::io::Error::other(format!(
+                "target path '{}' is not a file",
+                target_path.display()
+            )));
+        }
+
+        let backup_path = build_backup_path(target_path)?;
+        if let Some(parent) = backup_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        fs::copy(target_path, &backup_path)?;
+
+        Ok(BackupArtifact {
+            backup_path: Some(backup_path),
+            target_existed: true,
+        })
+    }
+
+    pub fn restore_backup(
+        &self,
+        target_path: &Path,
+        backup: &BackupArtifact,
+    ) -> std::io::Result<()> {
+        if backup.target_existed {
+            let Some(backup_path) = backup.backup_path.as_ref() else {
+                return Err(std::io::Error::other(
+                    "missing backup path for existing target",
+                ));
+            };
+            fs::copy(backup_path, target_path)?;
+        } else if target_path.exists() {
+            fs::remove_file(target_path)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for BackupManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn build_backup_path(target_path: &Path) -> std::io::Result<PathBuf> {
+    let parent = target_path.parent().ok_or_else(|| {
+        std::io::Error::other(format!(
+            "target path '{}' has no parent directory",
+            target_path.display()
+        ))
+    })?;
+
+    let filename = target_path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "target".to_string());
+    let timestamp_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(std::io::Error::other)?
+        .as_millis();
+
+    Ok(parent
+        .join(".ai-manager-backups")
+        .join(format!("{}.{}.bak", filename, timestamp_ms)))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::BackupManager;
+
+    #[test]
+    fn create_and_restore_backup_for_existing_file() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("ai-manager-backup-test-{}", std::process::id()));
+        let _ = fs::create_dir_all(&temp_dir);
+
+        let target = temp_dir.join("config.json");
+        fs::write(&target, "{\"before\":true}").expect("should create target file");
+
+        let manager = BackupManager::new();
+        let backup = manager
+            .create_backup(&target)
+            .expect("should create backup artifact");
+
+        fs::write(&target, "{\"before\":false}").expect("should mutate target");
+        manager
+            .restore_backup(&target, &backup)
+            .expect("should restore backup");
+
+        let restored = fs::read_to_string(&target).expect("should read restored target");
+        let _ = fs::remove_dir_all(&temp_dir);
+
+        assert_eq!(restored, "{\"before\":true}");
+        assert!(backup.backup_path.is_some());
+        assert!(backup.target_existed);
+    }
+}

--- a/src-tauri/src/infra/mutation/mod.rs
+++ b/src-tauri/src/infra/mutation/mod.rs
@@ -1,0 +1,5 @@
+mod atomic_writer;
+mod backup_manager;
+mod safe_file_mutator;
+
+pub use safe_file_mutator::{MutationTestHooks, SafeFileMutator};

--- a/src-tauri/src/infra/mutation/safe_file_mutator.rs
+++ b/src-tauri/src/infra/mutation/safe_file_mutator.rs
@@ -1,0 +1,208 @@
+use std::path::Path;
+
+use super::{
+    atomic_writer::AtomicWriter,
+    backup_manager::{BackupArtifact, BackupManager},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SafeFileMutationResult {
+    pub backup_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MutationStage {
+    Backup,
+    Write,
+    PostWriteValidation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MutationFailure {
+    pub stage: MutationStage,
+    pub message: String,
+    pub rollback_succeeded: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct MutationTestHooks {
+    pub fail_after_backup: bool,
+    pub fail_after_write: bool,
+}
+
+pub struct SafeFileMutator {
+    backup_manager: BackupManager,
+    atomic_writer: AtomicWriter,
+}
+
+impl SafeFileMutator {
+    pub fn new() -> Self {
+        Self {
+            backup_manager: BackupManager::new(),
+            atomic_writer: AtomicWriter::new(),
+        }
+    }
+
+    pub fn replace_file(
+        &self,
+        target_path: &Path,
+        new_content: &[u8],
+    ) -> Result<SafeFileMutationResult, MutationFailure> {
+        self.replace_file_with_hooks(target_path, new_content, MutationTestHooks::default())
+    }
+
+    pub(crate) fn replace_file_with_hooks(
+        &self,
+        target_path: &Path,
+        new_content: &[u8],
+        hooks: MutationTestHooks,
+    ) -> Result<SafeFileMutationResult, MutationFailure> {
+        let backup = self
+            .backup_manager
+            .create_backup(target_path)
+            .map_err(|error| MutationFailure {
+                stage: MutationStage::Backup,
+                message: error.to_string(),
+                rollback_succeeded: false,
+            })?;
+
+        if hooks.fail_after_backup {
+            return Err(self.rollback_with_error(
+                target_path,
+                &backup,
+                MutationStage::Backup,
+                "Injected failure after backup.".to_string(),
+            ));
+        }
+
+        if let Err(error) = self.atomic_writer.replace_file(target_path, new_content) {
+            return Err(self.rollback_with_error(
+                target_path,
+                &backup,
+                MutationStage::Write,
+                error.to_string(),
+            ));
+        }
+
+        if hooks.fail_after_write {
+            return Err(self.rollback_with_error(
+                target_path,
+                &backup,
+                MutationStage::PostWriteValidation,
+                "Injected failure after atomic write.".to_string(),
+            ));
+        }
+
+        Ok(SafeFileMutationResult {
+            backup_path: backup
+                .backup_path
+                .as_ref()
+                .map(|path| path.display().to_string()),
+        })
+    }
+
+    fn rollback_with_error(
+        &self,
+        target_path: &Path,
+        backup: &BackupArtifact,
+        stage: MutationStage,
+        original_message: String,
+    ) -> MutationFailure {
+        match self.backup_manager.restore_backup(target_path, backup) {
+            Ok(()) => MutationFailure {
+                stage,
+                message: original_message,
+                rollback_succeeded: true,
+            },
+            Err(rollback_error) => MutationFailure {
+                stage,
+                message: format!("{original_message} Rollback failed: {rollback_error}"),
+                rollback_succeeded: false,
+            },
+        }
+    }
+}
+
+impl Default for SafeFileMutator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::{MutationStage, MutationTestHooks, SafeFileMutator};
+
+    #[test]
+    fn successful_replace_creates_backup_and_updates_content() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("ai-manager-safe-mutate-{}", std::process::id()));
+        let _ = fs::create_dir_all(&temp_dir);
+        let target = temp_dir.join("mcp.json");
+        fs::write(&target, "{\"enabled\":false}").expect("should create target");
+
+        let result = SafeFileMutator::new()
+            .replace_file(&target, b"{\"enabled\":true}")
+            .expect("replace should succeed");
+
+        let content = fs::read_to_string(&target).expect("should read updated target");
+        let _ = fs::remove_dir_all(&temp_dir);
+
+        assert_eq!(content, "{\"enabled\":true}");
+        assert!(result.backup_path.is_some());
+    }
+
+    #[test]
+    fn rollback_restores_original_content_when_post_write_fails() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("ai-manager-safe-rollback-{}", std::process::id()));
+        let _ = fs::create_dir_all(&temp_dir);
+        let target = temp_dir.join("config.json");
+        fs::write(&target, "{\"version\":1}").expect("should create target");
+
+        let error = SafeFileMutator::new()
+            .replace_file_with_hooks(
+                &target,
+                b"{\"version\":2}",
+                MutationTestHooks {
+                    fail_after_backup: false,
+                    fail_after_write: true,
+                },
+            )
+            .expect_err("post-write failure should trigger rollback");
+
+        let content = fs::read_to_string(&target).expect("should read rolled back file");
+        let _ = fs::remove_dir_all(&temp_dir);
+
+        assert!(matches!(error.stage, MutationStage::PostWriteValidation));
+        assert!(error.rollback_succeeded);
+        assert_eq!(content, "{\"version\":1}");
+    }
+
+    #[test]
+    fn rollback_removes_new_file_when_target_did_not_exist() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("ai-manager-safe-new-file-{}", std::process::id()));
+        let _ = fs::create_dir_all(&temp_dir);
+        let target = temp_dir.join("new-config.json");
+
+        let error = SafeFileMutator::new()
+            .replace_file_with_hooks(
+                &target,
+                b"{\"created\":true}",
+                MutationTestHooks {
+                    fail_after_backup: false,
+                    fail_after_write: true,
+                },
+            )
+            .expect_err("post-write failure should rollback new file");
+
+        let _ = fs::remove_dir_all(&temp_dir);
+
+        assert!(matches!(error.stage, MutationStage::PostWriteValidation));
+        assert!(error.rollback_succeeded);
+        assert!(!target.exists());
+    }
+}


### PR DESCRIPTION
## Summary
- add `infra/mutation` module with dedicated backup manager, atomic writer, and safe mutator orchestration
- implement backup artifact handling for both existing and not-yet-existing target files
- implement atomic temp-file replace flow and rollback on post-write failures
- connect `mutate_resource` to this safe mutation path when payload includes `target_path` and `content`
- add rollback coverage tests at both infrastructure and application command levels

## Testing
- `pnpm run lint`
- `pnpm test`
- `cargo test --manifest-path src-tauri/Cargo.toml`

Closes #24