### PR TITLE
feat: implement skill add/remove mutation handlers (issue #26)

### DIFF
--- a/src-tauri/src/application/mod.rs
+++ b/src-tauri/src/application/mod.rs
@@ -5,6 +5,9 @@ mod mcp_mutation_payload;
 mod mcp_mutation_service;
 mod skill_listing_service;
 mod skill_metadata_parser;
+mod skill_mutation_path_resolver;
+mod skill_mutation_payload;
+mod skill_mutation_service;
 mod skill_path_resolver;
 
 pub use adapter_service::AdapterService;

--- a/src-tauri/src/application/skill_mutation_path_resolver.rs
+++ b/src-tauri/src/application/skill_mutation_path_resolver.rs
@@ -1,0 +1,55 @@
+use std::{env, path::PathBuf};
+
+use crate::contracts::{command::CommandError, common::ClientKind, mutate::MutationAction};
+
+use super::skill_path_resolver::{preferred_skill_dir, resolve_skill_dir};
+
+pub fn resolve_skill_root_path(
+    client: ClientKind,
+    action: MutationAction,
+    skills_dir_override: Option<&str>,
+) -> Result<PathBuf, CommandError> {
+    if let Some(skills_dir_override) = skills_dir_override {
+        let expanded = expand_user_path(skills_dir_override);
+        if matches!(action, MutationAction::Remove) && !expanded.is_dir() {
+            return Err(CommandError::validation(format!(
+                "skills_dir '{}' does not exist for skill remove mutation.",
+                expanded.display()
+            )));
+        }
+
+        return Ok(expanded);
+    }
+
+    let resolution = resolve_skill_dir(client);
+    if let Some(path) = resolution.path {
+        return Ok(path);
+    }
+
+    if matches!(action, MutationAction::Add) {
+        return Ok(preferred_skill_dir(client));
+    }
+
+    let warning = (!resolution.warnings.is_empty()).then(|| resolution.warnings.join(" | "));
+    match warning {
+        Some(warning) => Err(CommandError::validation(format!(
+            "Could not resolve skills directory for '{}'. {}",
+            client.as_str(),
+            warning
+        ))),
+        None => Err(CommandError::validation(format!(
+            "Could not resolve skills directory for '{}'.",
+            client.as_str()
+        ))),
+    }
+}
+
+fn expand_user_path(value: &str) -> PathBuf {
+    if let Some(stripped) = value.strip_prefix("~/")
+        && let Some(home) = env::var_os("HOME")
+    {
+        return PathBuf::from(home).join(stripped);
+    }
+
+    PathBuf::from(value)
+}

--- a/src-tauri/src/application/skill_mutation_payload.rs
+++ b/src-tauri/src/application/skill_mutation_payload.rs
@@ -1,0 +1,156 @@
+use crate::contracts::{command::CommandError, mutate::MutationAction};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillInstallKind {
+    Directory,
+    File,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SkillMutationPayload {
+    pub source_path: Option<String>,
+    pub skills_dir: Option<String>,
+    pub manifest: Option<String>,
+    pub install_kind: Option<SkillInstallKind>,
+    pub fail_after_write: bool,
+}
+
+pub fn parse_skill_mutation_payload(
+    action: MutationAction,
+    payload: Option<&serde_json::Value>,
+) -> Result<SkillMutationPayload, CommandError> {
+    let Some(payload) = payload else {
+        return if matches!(action, MutationAction::Remove) {
+            Ok(SkillMutationPayload::default())
+        } else {
+            Err(CommandError::validation(
+                "payload is required for skill add mutation.",
+            ))
+        };
+    };
+
+    let source_path = read_trimmed_string(payload, "source_path");
+    let skills_dir = read_trimmed_string(payload, "skills_dir");
+    let manifest = read_manifest(payload);
+    let fail_after_write = payload
+        .get("fail_after_write")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    let install_kind = if let Some(raw_kind) = payload
+        .get("install_kind")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(parse_install_kind(raw_kind)?)
+    } else {
+        None
+    };
+
+    if source_path.is_some() && manifest.is_some() {
+        return Err(CommandError::validation(
+            "payload.source_path and payload.manifest cannot be used together.",
+        ));
+    }
+
+    if matches!(action, MutationAction::Add) && source_path.is_none() && manifest.is_none() {
+        return Err(CommandError::validation(
+            "payload.manifest or payload.source_path is required for skill add mutation.",
+        ));
+    }
+
+    Ok(SkillMutationPayload {
+        source_path,
+        skills_dir,
+        manifest,
+        install_kind,
+        fail_after_write,
+    })
+}
+
+fn read_trimmed_string(payload: &serde_json::Value, key: &str) -> Option<String> {
+    payload
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn read_manifest(payload: &serde_json::Value) -> Option<String> {
+    payload
+        .get("manifest")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn parse_install_kind(value: &str) -> Result<SkillInstallKind, CommandError> {
+    match value {
+        "directory" => Ok(SkillInstallKind::Directory),
+        "file" => Ok(SkillInstallKind::File),
+        _ => Err(CommandError::validation(
+            "payload.install_kind must be either 'directory' or 'file'.",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::contracts::mutate::MutationAction;
+
+    use super::{SkillInstallKind, parse_skill_mutation_payload};
+
+    #[test]
+    fn add_requires_manifest_or_source_path() {
+        let error = parse_skill_mutation_payload(MutationAction::Add, Some(&json!({})))
+            .expect_err("add payload should require a source");
+
+        assert!(
+            error
+                .message
+                .contains("payload.manifest or payload.source_path")
+        );
+    }
+
+    #[test]
+    fn add_with_manifest_parses_install_kind() {
+        let payload = parse_skill_mutation_payload(
+            MutationAction::Add,
+            Some(&json!({
+                "manifest": "# Python Refactor\n\nRefactor Python code safely.\n",
+                "install_kind": "file"
+            })),
+        )
+        .expect("payload should parse");
+
+        assert!(matches!(payload.install_kind, Some(SkillInstallKind::File)));
+        assert!(payload.source_path.is_none());
+    }
+
+    #[test]
+    fn source_and_manifest_are_mutually_exclusive() {
+        let error = parse_skill_mutation_payload(
+            MutationAction::Add,
+            Some(&json!({
+                "source_path": "/tmp/skill.md",
+                "manifest": "# Skill\n\nContent\n"
+            })),
+        )
+        .expect_err("source_path + manifest should fail");
+
+        assert!(error.message.contains("cannot be used together"));
+    }
+
+    #[test]
+    fn remove_payload_is_optional() {
+        let payload = parse_skill_mutation_payload(MutationAction::Remove, None)
+            .expect("remove payload should be optional");
+
+        assert!(payload.source_path.is_none());
+        assert!(payload.manifest.is_none());
+    }
+}

--- a/src-tauri/src/application/skill_mutation_service.rs
+++ b/src-tauri/src/application/skill_mutation_service.rs
@@ -1,0 +1,543 @@
+use std::{
+    env, fs,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
+
+use crate::{
+    contracts::{command::CommandError, common::ClientKind, mutate::MutationAction},
+    infra::{MutationTestHooks, SafeFileMutator},
+};
+
+use super::{
+    skill_metadata_parser::parse_skill_metadata,
+    skill_mutation_path_resolver::resolve_skill_root_path,
+    skill_mutation_payload::{
+        SkillInstallKind, SkillMutationPayload, parse_skill_mutation_payload,
+    },
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillMutationResult {
+    pub source_path: String,
+    pub message: String,
+}
+
+pub struct SkillMutationService;
+
+impl SkillMutationService {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn mutate(
+        &self,
+        client: ClientKind,
+        action: MutationAction,
+        target_id: &str,
+        payload: Option<&serde_json::Value>,
+    ) -> Result<SkillMutationResult, CommandError> {
+        validate_skill_target_id(target_id)?;
+        let payload = parse_skill_mutation_payload(action, payload)?;
+
+        match action {
+            MutationAction::Add => add_skill(client, target_id, &payload),
+            MutationAction::Remove => remove_skill(client, target_id, &payload),
+        }
+    }
+}
+
+impl Default for SkillMutationService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SkillManifestSource {
+    manifest: String,
+    install_kind: SkillInstallKind,
+    source_path: Option<PathBuf>,
+}
+
+fn add_skill(
+    client: ClientKind,
+    target_id: &str,
+    payload: &SkillMutationPayload,
+) -> Result<SkillMutationResult, CommandError> {
+    let root_path =
+        resolve_skill_root_path(client, MutationAction::Add, payload.skills_dir.as_deref())?;
+    let manifest_source = resolve_manifest_source(payload)?;
+
+    let metadata = parse_skill_metadata(&manifest_source.manifest);
+    if metadata.description.is_none() {
+        return Err(CommandError::validation(
+            "Skill manifest metadata is incompatible: include at least one heading or description line.",
+        ));
+    }
+
+    let install_kind = payload.install_kind.unwrap_or(manifest_source.install_kind);
+    let directory_manifest = directory_manifest_path(&root_path, target_id);
+    let file_manifest = file_manifest_path(&root_path, target_id);
+    let destination_manifest = match install_kind {
+        SkillInstallKind::Directory => directory_manifest.clone(),
+        SkillInstallKind::File => file_manifest.clone(),
+    };
+
+    let mut conflicts: Vec<String> = Vec::new();
+    if directory_manifest.exists() {
+        conflicts.push(directory_manifest.display().to_string());
+    }
+    if file_manifest.exists() {
+        conflicts.push(file_manifest.display().to_string());
+    }
+    if !conflicts.is_empty() {
+        return Err(CommandError::validation(format!(
+            "Skill '{}' already exists. Conflicts: {}",
+            target_id,
+            conflicts.join(", ")
+        )));
+    }
+
+    if let Some(parent) = destination_manifest.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            CommandError::internal(format!(
+                "Failed to create skill destination directory '{}': {}",
+                parent.display(),
+                error
+            ))
+        })?;
+    }
+
+    let mutator = SafeFileMutator::new();
+    let outcome = if payload.fail_after_write {
+        mutator.replace_file_with_hooks(
+            &destination_manifest,
+            manifest_source.manifest.as_bytes(),
+            MutationTestHooks {
+                fail_after_backup: false,
+                fail_after_write: true,
+            },
+        )
+    } else {
+        mutator.replace_file(&destination_manifest, manifest_source.manifest.as_bytes())
+    }
+    .map_err(|failure| {
+        CommandError::internal(format!(
+            "[stage={:?}] {} (rollback_succeeded={})",
+            failure.stage, failure.message, failure.rollback_succeeded
+        ))
+    })?;
+
+    let mut message = format!(
+        "Added skill '{}' for '{}'. Installed at '{}'.",
+        target_id,
+        client.as_str(),
+        destination_manifest.display()
+    );
+    if let Some(source_path) = manifest_source.source_path {
+        message.push_str(&format!(" Source: {}.", source_path.display()));
+    }
+    if let Some(backup_path) = outcome.backup_path {
+        message.push_str(&format!(" Backup: {}.", backup_path));
+    }
+
+    Ok(SkillMutationResult {
+        source_path: destination_manifest.display().to_string(),
+        message,
+    })
+}
+
+fn remove_skill(
+    client: ClientKind,
+    target_id: &str,
+    payload: &SkillMutationPayload,
+) -> Result<SkillMutationResult, CommandError> {
+    let root_path = resolve_skill_root_path(
+        client,
+        MutationAction::Remove,
+        payload.skills_dir.as_deref(),
+    )?;
+    let removal_targets =
+        resolve_removal_targets(&root_path, target_id, payload.source_path.as_deref())?;
+
+    for target in &removal_targets {
+        fs::remove_file(target).map_err(|error| {
+            CommandError::internal(format!(
+                "Failed to remove skill manifest '{}': {}",
+                target.display(),
+                error
+            ))
+        })?;
+    }
+
+    for target in &removal_targets {
+        cleanup_skill_directory_if_empty(target)?;
+    }
+
+    let mut message = format!("Removed skill '{}' for '{}'.", target_id, client.as_str());
+    if removal_targets.len() > 1 {
+        message.push_str(" Cleaned up stale skill entries.");
+    }
+    message.push_str(&format!(
+        " Removed: {}.",
+        removal_targets
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+
+    Ok(SkillMutationResult {
+        source_path: removal_targets
+            .first()
+            .map(|path| path.display().to_string())
+            .unwrap_or_default(),
+        message,
+    })
+}
+
+fn resolve_manifest_source(
+    payload: &SkillMutationPayload,
+) -> Result<SkillManifestSource, CommandError> {
+    if let Some(source_path) = payload.source_path.as_deref() {
+        let source_path = expand_user_path(source_path);
+        let (manifest_path, inferred_kind) = if source_path.is_dir() {
+            let manifest_path = source_path.join("SKILL.md");
+            if !manifest_path.is_file() {
+                return Err(CommandError::validation(format!(
+                    "source_path '{}' must contain SKILL.md when using directory install.",
+                    source_path.display()
+                )));
+            }
+            (manifest_path, SkillInstallKind::Directory)
+        } else if source_path.is_file() {
+            let extension = source_path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .unwrap_or_default();
+            if !extension.eq_ignore_ascii_case("md") {
+                return Err(CommandError::validation(format!(
+                    "source_path '{}' must point to a markdown file.",
+                    source_path.display()
+                )));
+            }
+            (source_path.clone(), SkillInstallKind::File)
+        } else {
+            return Err(CommandError::validation(format!(
+                "source_path '{}' does not exist.",
+                source_path.display()
+            )));
+        };
+
+        if let Some(requested_kind) = payload.install_kind
+            && requested_kind != inferred_kind
+        {
+            return Err(CommandError::validation(
+                "payload.install_kind is incompatible with payload.source_path shape.",
+            ));
+        }
+
+        let manifest = fs::read_to_string(&manifest_path).map_err(|error| {
+            CommandError::internal(format!(
+                "Failed to read skill source manifest '{}': {}",
+                manifest_path.display(),
+                error
+            ))
+        })?;
+
+        return Ok(SkillManifestSource {
+            manifest,
+            install_kind: inferred_kind,
+            source_path: Some(manifest_path),
+        });
+    }
+
+    let Some(manifest) = payload.manifest.clone() else {
+        return Err(CommandError::validation(
+            "payload.manifest or payload.source_path is required for skill add mutation.",
+        ));
+    };
+
+    Ok(SkillManifestSource {
+        manifest,
+        install_kind: payload.install_kind.unwrap_or(SkillInstallKind::Directory),
+        source_path: None,
+    })
+}
+
+fn resolve_removal_targets(
+    root_path: &Path,
+    target_id: &str,
+    source_path_override: Option<&str>,
+) -> Result<Vec<PathBuf>, CommandError> {
+    if let Some(source_path_override) = source_path_override {
+        let source_path = expand_user_path(source_path_override);
+        let manifest_path = if source_path.is_dir() {
+            source_path.join("SKILL.md")
+        } else {
+            source_path
+        };
+
+        if !manifest_path.is_file() {
+            return Err(CommandError::validation(format!(
+                "source_path '{}' does not exist.",
+                manifest_path.display()
+            )));
+        }
+
+        return Ok(vec![manifest_path]);
+    }
+
+    let mut targets: Vec<PathBuf> = Vec::new();
+    let directory_manifest = directory_manifest_path(root_path, target_id);
+    if directory_manifest.is_file() {
+        targets.push(directory_manifest);
+    }
+
+    let file_manifest = file_manifest_path(root_path, target_id);
+    if file_manifest.is_file() {
+        targets.push(file_manifest);
+    }
+
+    if targets.is_empty() {
+        return Err(CommandError::validation(format!(
+            "Skill '{}' does not exist.",
+            target_id
+        )));
+    }
+
+    targets.sort_unstable_by(|left, right| left.as_os_str().cmp(right.as_os_str()));
+    Ok(targets)
+}
+
+fn validate_skill_target_id(target_id: &str) -> Result<(), CommandError> {
+    if target_id.contains('/') || target_id.contains('\\') || target_id.contains("..") {
+        return Err(CommandError::validation(
+            "target_id must not contain path separators or traversal segments for skill mutation.",
+        ));
+    }
+
+    Ok(())
+}
+
+fn directory_manifest_path(root_path: &Path, target_id: &str) -> PathBuf {
+    root_path.join(target_id).join("SKILL.md")
+}
+
+fn file_manifest_path(root_path: &Path, target_id: &str) -> PathBuf {
+    root_path.join(format!("{target_id}.md"))
+}
+
+fn cleanup_skill_directory_if_empty(manifest_path: &Path) -> Result<(), CommandError> {
+    if manifest_path.file_name().and_then(|name| name.to_str()) != Some("SKILL.md") {
+        return Ok(());
+    }
+
+    let Some(parent) = manifest_path.parent() else {
+        return Ok(());
+    };
+
+    match fs::remove_dir(parent) {
+        Ok(()) => Ok(()),
+        Err(error)
+            if matches!(
+                error.kind(),
+                ErrorKind::NotFound | ErrorKind::DirectoryNotEmpty
+            ) =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(CommandError::internal(format!(
+            "Failed to clean up empty skill directory '{}': {}",
+            parent.display(),
+            error
+        ))),
+    }
+}
+
+fn expand_user_path(value: &str) -> PathBuf {
+    if let Some(stripped) = value.strip_prefix("~/")
+        && let Some(home) = env::var_os("HOME")
+    {
+        return PathBuf::from(home).join(stripped);
+    }
+
+    PathBuf::from(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::contracts::{common::ClientKind, mutate::MutationAction};
+
+    use super::SkillMutationService;
+
+    #[test]
+    fn add_skill_with_manifest_creates_directory_install() {
+        let root = test_root("add-manifest");
+        let _ = fs::create_dir_all(&root);
+
+        let service = SkillMutationService::new();
+        let result = service
+            .mutate(
+                ClientKind::Cursor,
+                MutationAction::Add,
+                "python-refactor",
+                Some(&json!({
+                    "skills_dir": root.display().to_string(),
+                    "manifest": "# Python Refactor\n\nRefactor Python safely.\n"
+                })),
+            )
+            .expect("add should succeed");
+
+        let installed_manifest = root.join("python-refactor").join("SKILL.md");
+        let content = fs::read_to_string(&installed_manifest).expect("manifest should exist");
+        let _ = fs::remove_dir_all(&root);
+
+        assert!(content.contains("Python Refactor"));
+        assert_eq!(result.source_path, installed_manifest.display().to_string());
+    }
+
+    #[test]
+    fn add_duplicate_skill_is_validation_error_and_non_destructive() {
+        let root = test_root("duplicate");
+        let existing_manifest = root.join("python-refactor").join("SKILL.md");
+        let _ = fs::create_dir_all(existing_manifest.parent().expect("parent should exist"));
+        let original = "# Existing Skill\n\nExisting description.\n";
+        fs::write(&existing_manifest, original).expect("should write existing manifest");
+
+        let service = SkillMutationService::new();
+        let error = service
+            .mutate(
+                ClientKind::ClaudeCode,
+                MutationAction::Add,
+                "python-refactor",
+                Some(&json!({
+                    "skills_dir": root.display().to_string(),
+                    "manifest": "# New Skill\n\nNew description.\n"
+                })),
+            )
+            .expect_err("duplicate add should fail");
+
+        let content = fs::read_to_string(&existing_manifest).expect("original should remain");
+        let _ = fs::remove_dir_all(&root);
+
+        assert!(error.message.contains("already exists"));
+        assert_eq!(content, original);
+    }
+
+    #[test]
+    fn add_rejects_incompatible_metadata() {
+        let root = test_root("incompatible");
+        let _ = fs::create_dir_all(&root);
+
+        let service = SkillMutationService::new();
+        let error = service
+            .mutate(
+                ClientKind::CodexCli,
+                MutationAction::Add,
+                "python-refactor",
+                Some(&json!({
+                    "skills_dir": root.display().to_string(),
+                    "manifest": "#\n"
+                })),
+            )
+            .expect_err("incompatible metadata should fail");
+
+        let _ = fs::remove_dir_all(&root);
+
+        assert!(error.message.contains("incompatible"));
+    }
+
+    #[test]
+    fn add_rolls_back_when_post_write_failure_is_injected() {
+        let root = test_root("rollback");
+        let _ = fs::create_dir_all(&root);
+        let target_manifest = root.join("python-refactor").join("SKILL.md");
+
+        let service = SkillMutationService::new();
+        let error = service
+            .mutate(
+                ClientKind::CodexApp,
+                MutationAction::Add,
+                "python-refactor",
+                Some(&json!({
+                    "skills_dir": root.display().to_string(),
+                    "manifest": "# Skill\n\nDescription.\n",
+                    "fail_after_write": true
+                })),
+            )
+            .expect_err("injected failure should rollback");
+
+        let _ = fs::remove_dir_all(&root);
+
+        assert!(error.message.contains("rollback_succeeded=true"));
+        assert!(!target_manifest.exists());
+    }
+
+    #[test]
+    fn remove_cleans_stale_directory_and_file_entries() {
+        let root = test_root("stale-remove");
+        let directory_manifest = root.join("python-refactor").join("SKILL.md");
+        let _ = fs::create_dir_all(directory_manifest.parent().expect("parent should exist"));
+        fs::write(&directory_manifest, "# Skill\n\nDirectory install.\n")
+            .expect("should write directory manifest");
+
+        let file_manifest = root.join("python-refactor.md");
+        fs::write(&file_manifest, "# Skill\n\nFile install.\n")
+            .expect("should write file manifest");
+
+        let service = SkillMutationService::new();
+        let result = service
+            .mutate(
+                ClientKind::Cursor,
+                MutationAction::Remove,
+                "python-refactor",
+                Some(&json!({
+                    "skills_dir": root.display().to_string()
+                })),
+            )
+            .expect("remove should succeed");
+
+        let _ = fs::remove_dir_all(&root);
+
+        assert!(result.message.contains("stale skill entries"));
+        assert!(!directory_manifest.exists());
+        assert!(!file_manifest.exists());
+    }
+
+    #[test]
+    fn remove_missing_skill_is_validation_error() {
+        let root = test_root("remove-missing");
+        let _ = fs::create_dir_all(&root);
+
+        let service = SkillMutationService::new();
+        let error = service
+            .mutate(
+                ClientKind::ClaudeCode,
+                MutationAction::Remove,
+                "python-refactor",
+                Some(&json!({
+                    "skills_dir": root.display().to_string()
+                })),
+            )
+            .expect_err("missing skill should fail");
+
+        let _ = fs::remove_dir_all(&root);
+
+        assert!(error.message.contains("does not exist"));
+    }
+
+    fn test_root(suffix: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "ai-manager-skill-mutation-{}-{}",
+            std::process::id(),
+            suffix
+        ))
+    }
+}

--- a/src-tauri/src/application/skill_path_resolver.rs
+++ b/src-tauri/src/application/skill_path_resolver.rs
@@ -18,6 +18,20 @@ pub fn resolve_skill_dir(client: ClientKind) -> SkillDirResolution {
     resolve_skill_dir_with_override(client, override_value.as_deref())
 }
 
+pub fn preferred_skill_dir(client: ClientKind) -> PathBuf {
+    let profile = profile_for_client(client);
+
+    if let Some(override_value) = read_env_value(profile.override_env_var) {
+        return expand_user_path(&override_value);
+    }
+
+    profile
+        .fallback_paths
+        .first()
+        .map(|path| expand_user_path(path))
+        .unwrap_or_default()
+}
+
 pub fn resolve_skill_dir_with_override(
     client: ClientKind,
     override_value: Option<&str>,


### PR DESCRIPTION
## Summary
- add skill mutation payload parser with source/manifest and install-kind validation
- add skill root path resolver for add/remove mutation flows
- implement skill add/remove service with duplicate detection, stale cleanup, and metadata compatibility checks
- route skill mutations through `AdapterService` and return source metadata in mutation responses
- add unit tests for payload parsing, service behavior, rollback coverage, and adapter integration

## Validation
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `pnpm exec biome check --write .`
- `pnpm run lint`
- `pnpm test`
- `cargo test --manifest-path src-tauri/Cargo.toml`

Closes #26