### PR TITLE
feat: implement MCP management tab with add/remove flows (issue #28)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -179,6 +179,130 @@ select {
   line-height: 1.4;
 }
 
+.mcp-panel {
+  border-radius: 1rem;
+  border: 1px solid rgba(29, 61, 91, 0.2);
+  background: #f7fbff;
+  padding: 1rem;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.mcp-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 0.6rem;
+}
+
+.mcp-header p {
+  color: #3d5470;
+  margin-top: 0.25rem;
+}
+
+.mcp-feedback {
+  margin: 0;
+  border-radius: 0.8rem;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.9rem;
+}
+
+.mcp-feedback-warning {
+  background: #fff4d4;
+  color: #805f09;
+}
+
+.mcp-feedback-error {
+  background: #ffe7e7;
+  color: #8f2727;
+}
+
+.mcp-feedback-success {
+  background: #ddf8e8;
+  color: #135e37;
+}
+
+.mcp-layout {
+  display: grid;
+  grid-template-columns: minmax(14rem, 18.5rem) 1fr;
+  gap: 0.75rem;
+}
+
+.mcp-form {
+  display: grid;
+  align-content: start;
+  gap: 0.45rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(31, 64, 95, 0.2);
+  background: #ffffff;
+  padding: 0.85rem;
+}
+
+.mcp-form h3 {
+  margin-bottom: 0.2rem;
+}
+
+.mcp-form label {
+  font-size: 0.82rem;
+  letter-spacing: 0.03em;
+  color: #445972;
+}
+
+.mcp-form input,
+.mcp-form select {
+  border-radius: 0.62rem;
+  border: 1px solid #bbcadc;
+  padding: 0.52rem 0.62rem;
+}
+
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.checkbox-row input {
+  width: 1rem;
+  height: 1rem;
+}
+
+.mcp-table-wrapper {
+  overflow: auto;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(32, 63, 90, 0.18);
+  background: #ffffff;
+}
+
+.mcp-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 35rem;
+}
+
+.mcp-table th,
+.mcp-table td {
+  text-align: left;
+  padding: 0.66rem;
+  border-bottom: 1px solid rgba(40, 71, 102, 0.12);
+  font-size: 0.88rem;
+}
+
+.mcp-table thead th {
+  font-size: 0.77rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #526a86;
+}
+
+.mcp-table-action-cell {
+  width: 6.2rem;
+}
+
+.mcp-empty {
+  margin: 0;
+  color: #485f7a;
+}
+
 .client-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(16.3rem, 1fr));
@@ -339,5 +463,13 @@ select {
 
   .nav-list {
     grid-template-columns: 1fr;
+  }
+
+  .mcp-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .mcp-table {
+    min-width: 0;
   }
 }

--- a/src/features/app-shell/AppShell.tsx
+++ b/src/features/app-shell/AppShell.tsx
@@ -5,6 +5,7 @@ import { formatClientLabel } from "../clients/client-labels";
 import { ClientStatusCard } from "../clients/components/ClientStatusCard";
 import { useClientDetections } from "../clients/useClientDetections";
 import { ViewStatePanel } from "../common/ViewStatePanel";
+import { McpManagerPanel } from "../mcp/McpManagerPanel";
 import { type AppRoute, NAVIGATION_ITEMS } from "./navigation";
 
 function findSelectedDetection(
@@ -23,6 +24,10 @@ function renderRouteContent(route: AppRoute, selectedDetection: ClientDetection 
     return null;
   }
 
+  if (route === "mcp") {
+    return <McpManagerPanel client={selectedDetection?.client ?? null} />;
+  }
+
   if (selectedDetection === null) {
     return (
       <ViewStatePanel
@@ -32,17 +37,13 @@ function renderRouteContent(route: AppRoute, selectedDetection: ClientDetection 
     );
   }
 
-  const featureName = route === "mcp" ? "MCP Manager" : "Skills Manager";
   return (
     <section className="feature-placeholder">
-      <h2>{featureName}</h2>
+      <h2>Skills Manager</h2>
       <p>
         Selected client: <strong>{formatClientLabel(selectedDetection.client)}</strong>
       </p>
-      <p>
-        This route scaffold is ready. Interactive add/remove flows are tracked in issue{" "}
-        {route === "mcp" ? "#28" : "#29"}.
-      </p>
+      <p>This route scaffold is ready. Interactive add/remove flows are tracked in issue #29.</p>
     </section>
   );
 }

--- a/src/features/mcp/McpManagerPanel.tsx
+++ b/src/features/mcp/McpManagerPanel.tsx
@@ -1,0 +1,93 @@
+import type { ClientKind, ResourceRecord } from "../../backend/contracts";
+import { formatClientLabel } from "../clients/client-labels";
+import { ViewStatePanel } from "../common/ViewStatePanel";
+import { McpAddForm } from "./components/McpAddForm";
+import { McpResourceTable } from "./components/McpResourceTable";
+import { useMcpManager } from "./useMcpManager";
+
+interface McpManagerPanelProps {
+  client: ClientKind | null;
+}
+
+export function McpManagerPanel({ client }: McpManagerPanelProps) {
+  const {
+    phase,
+    resources,
+    warning,
+    operationError,
+    feedback,
+    pendingRemovalId,
+    addMcp,
+    removeMcp,
+    refresh,
+    clearFeedback,
+  } = useMcpManager(client);
+
+  async function handleRemove(resource: ResourceRecord) {
+    if (
+      !window.confirm(
+        `Remove MCP '${resource.display_name}' from ${formatClientLabel(resource.client)}?`,
+      )
+    ) {
+      return;
+    }
+
+    await removeMcp(resource.display_name, resource.source_path);
+  }
+
+  if (client === null) {
+    return (
+      <ViewStatePanel
+        title="Client Selection Required"
+        message="Select a client to list and mutate MCP entries."
+      />
+    );
+  }
+
+  return (
+    <section className="mcp-panel">
+      <header className="mcp-header">
+        <div>
+          <h2>MCP Manager</h2>
+          <p>
+            Managing <strong>{formatClientLabel(client)}</strong>
+          </p>
+        </div>
+        <button
+          type="button"
+          className="ghost-button"
+          onClick={() => {
+            clearFeedback();
+            void refresh();
+          }}
+          disabled={phase === "loading"}
+        >
+          {phase === "loading" ? "Loading..." : "Reload MCP List"}
+        </button>
+      </header>
+
+      {warning ? <p className="mcp-feedback mcp-feedback-warning">{warning}</p> : null}
+      {operationError ? <p className="mcp-feedback mcp-feedback-error">{operationError}</p> : null}
+      {feedback ? (
+        <p
+          className={
+            feedback.kind === "success"
+              ? "mcp-feedback mcp-feedback-success"
+              : "mcp-feedback mcp-feedback-error"
+          }
+        >
+          {feedback.message}
+        </p>
+      ) : null}
+
+      <div className="mcp-layout">
+        <McpAddForm disabled={phase === "loading"} onSubmit={addMcp} />
+        <McpResourceTable
+          resources={resources}
+          pendingRemovalId={pendingRemovalId}
+          onRemove={handleRemove}
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/features/mcp/components/McpAddForm.tsx
+++ b/src/features/mcp/components/McpAddForm.tsx
@@ -1,0 +1,167 @@
+import { type FormEvent, useState } from "react";
+
+import type { AddMcpInput, McpTransportInput } from "../useMcpManager";
+
+interface McpAddFormProps {
+  disabled: boolean;
+  onSubmit: (input: AddMcpInput) => Promise<boolean>;
+}
+
+type TransportMode = "stdio" | "sse";
+
+function parseArgs(rawArgs: string): string[] {
+  return rawArgs
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+function createTransportPayload(
+  mode: TransportMode,
+  command: string,
+  argsInput: string,
+  url: string,
+): { transport: McpTransportInput | null; error: string | null } {
+  if (mode === "stdio") {
+    if (command.trim().length === 0) {
+      return { transport: null, error: "Command is required for stdio transport." };
+    }
+
+    return {
+      transport: {
+        kind: "stdio",
+        command: command.trim(),
+        args: parseArgs(argsInput),
+      },
+      error: null,
+    };
+  }
+
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    return { transport: null, error: "SSE URL must start with http:// or https://." };
+  }
+
+  return {
+    transport: {
+      kind: "sse",
+      url: url.trim(),
+    },
+    error: null,
+  };
+}
+
+export function McpAddForm({ disabled, onSubmit }: McpAddFormProps) {
+  const [targetId, setTargetId] = useState("example.server");
+  const [transportMode, setTransportMode] = useState<TransportMode>("stdio");
+  const [command, setCommand] = useState("npx");
+  const [argsInput, setArgsInput] = useState("-y, @modelcontextprotocol/server-filesystem");
+  const [url, setUrl] = useState("https://example.com/sse");
+  const [enabled, setEnabled] = useState(true);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLocalError(null);
+
+    const normalizedTargetId = targetId.trim();
+    if (normalizedTargetId.length === 0) {
+      setLocalError("Target ID is required.");
+      return;
+    }
+
+    const { transport, error } = createTransportPayload(transportMode, command, argsInput, url);
+    if (error || transport === null) {
+      setLocalError(error ?? "Transport configuration is invalid.");
+      return;
+    }
+
+    const accepted = await onSubmit({
+      targetId: normalizedTargetId,
+      transport,
+      enabled,
+    });
+
+    if (accepted) {
+      setTargetId("");
+      if (transportMode === "sse") {
+        setUrl("https://example.com/sse");
+      }
+    }
+  }
+
+  return (
+    <form className="mcp-form" onSubmit={(event) => void handleSubmit(event)}>
+      <h3>Add MCP Entry</h3>
+
+      {localError ? <p className="mcp-feedback mcp-feedback-error">{localError}</p> : null}
+
+      <label htmlFor="mcp-target-id">Target ID</label>
+      <input
+        id="mcp-target-id"
+        value={targetId}
+        onChange={(event) => setTargetId(event.currentTarget.value)}
+        placeholder="filesystem"
+        disabled={disabled}
+      />
+
+      <label htmlFor="mcp-transport-mode">Transport</label>
+      <select
+        id="mcp-transport-mode"
+        value={transportMode}
+        onChange={(event) => setTransportMode(event.currentTarget.value as TransportMode)}
+        disabled={disabled}
+      >
+        <option value="stdio">stdio (command + args)</option>
+        <option value="sse">sse (url)</option>
+      </select>
+
+      {transportMode === "stdio" ? (
+        <>
+          <label htmlFor="mcp-command">Command</label>
+          <input
+            id="mcp-command"
+            value={command}
+            onChange={(event) => setCommand(event.currentTarget.value)}
+            placeholder="npx"
+            disabled={disabled}
+          />
+
+          <label htmlFor="mcp-args">Args (comma-separated)</label>
+          <input
+            id="mcp-args"
+            value={argsInput}
+            onChange={(event) => setArgsInput(event.currentTarget.value)}
+            placeholder="-y, @scope/package"
+            disabled={disabled}
+          />
+        </>
+      ) : (
+        <>
+          <label htmlFor="mcp-url">SSE URL</label>
+          <input
+            id="mcp-url"
+            value={url}
+            onChange={(event) => setUrl(event.currentTarget.value)}
+            placeholder="https://example.com/sse"
+            disabled={disabled}
+          />
+        </>
+      )}
+
+      <label className="checkbox-row" htmlFor="mcp-enabled">
+        <input
+          id="mcp-enabled"
+          type="checkbox"
+          checked={enabled}
+          onChange={(event) => setEnabled(event.currentTarget.checked)}
+          disabled={disabled}
+        />
+        Enable this MCP entry immediately
+      </label>
+
+      <button className="ghost-button" type="submit" disabled={disabled}>
+        Add MCP
+      </button>
+    </form>
+  );
+}

--- a/src/features/mcp/components/McpResourceTable.tsx
+++ b/src/features/mcp/components/McpResourceTable.tsx
@@ -1,0 +1,62 @@
+import type { ResourceRecord } from "../../../backend/contracts";
+
+interface McpResourceTableProps {
+  resources: ResourceRecord[];
+  pendingRemovalId: string | null;
+  onRemove: (resource: ResourceRecord) => Promise<void>;
+}
+
+function formatSourcePath(sourcePath: string | null): string {
+  return sourcePath ?? "Auto-resolved";
+}
+
+function formatTransportKind(value: string | null): string {
+  return value ?? "unknown";
+}
+
+export function McpResourceTable({ resources, pendingRemovalId, onRemove }: McpResourceTableProps) {
+  if (resources.length === 0) {
+    return <p className="mcp-empty">No MCP entries registered for the selected client.</p>;
+  }
+
+  return (
+    <div className="mcp-table-wrapper">
+      <table className="mcp-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Transport</th>
+            <th>Enabled</th>
+            <th>Source</th>
+            <th aria-label="actions" />
+          </tr>
+        </thead>
+        <tbody>
+          {resources.map((resource) => {
+            const removing = pendingRemovalId === resource.display_name;
+            return (
+              <tr key={resource.id}>
+                <td>{resource.display_name}</td>
+                <td>{formatTransportKind(resource.transport_kind)}</td>
+                <td>{resource.enabled ? "yes" : "no"}</td>
+                <td>{formatSourcePath(resource.source_path)}</td>
+                <td className="mcp-table-action-cell">
+                  <button
+                    type="button"
+                    className="ghost-button"
+                    onClick={() => {
+                      void onRemove(resource);
+                    }}
+                    disabled={removing}
+                  >
+                    {removing ? "Removing..." : "Remove"}
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/features/mcp/useMcpManager.ts
+++ b/src/features/mcp/useMcpManager.ts
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { listResources, mutateResource } from "../../backend/client";
+import type { ClientKind, CommandEnvelope, ResourceRecord } from "../../backend/contracts";
+
+export type McpTransportInput =
+  | {
+      kind: "stdio";
+      command: string;
+      args: string[];
+    }
+  | {
+      kind: "sse";
+      url: string;
+    };
+
+export interface AddMcpInput {
+  targetId: string;
+  transport: McpTransportInput;
+  enabled: boolean;
+}
+
+interface MutationFeedback {
+  kind: "success" | "error";
+  message: string;
+}
+
+type LoadPhase = "idle" | "loading" | "ready" | "error";
+
+interface UseMcpManagerResult {
+  phase: LoadPhase;
+  resources: ResourceRecord[];
+  warning: string | null;
+  operationError: string | null;
+  feedback: MutationFeedback | null;
+  pendingRemovalId: string | null;
+  sourcePathHint: string | null;
+  refresh: () => Promise<void>;
+  addMcp: (input: AddMcpInput) => Promise<boolean>;
+  removeMcp: (targetId: string, sourcePath: string | null) => Promise<boolean>;
+  clearFeedback: () => void;
+}
+
+function envelopeErrorMessage(envelope: CommandEnvelope<unknown>): string {
+  if (envelope.error?.message) {
+    return envelope.error.message;
+  }
+  return "Command failed without an explicit error payload.";
+}
+
+function sortResources(resources: ResourceRecord[]): ResourceRecord[] {
+  return [...resources].sort((left, right) => {
+    if (left.display_name !== right.display_name) {
+      return left.display_name.localeCompare(right.display_name);
+    }
+    return left.id.localeCompare(right.id);
+  });
+}
+
+export function useMcpManager(client: ClientKind | null): UseMcpManagerResult {
+  const [phase, setPhase] = useState<LoadPhase>("idle");
+  const [resources, setResources] = useState<ResourceRecord[]>([]);
+  const [warning, setWarning] = useState<string | null>(null);
+  const [operationError, setOperationError] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<MutationFeedback | null>(null);
+  const [pendingRemovalId, setPendingRemovalId] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (client === null) {
+      setPhase("idle");
+      setResources([]);
+      setWarning(null);
+      setOperationError(null);
+      return;
+    }
+
+    setPhase("loading");
+    setOperationError(null);
+
+    try {
+      const envelope = await listResources({
+        client,
+        resource_kind: "mcp",
+      });
+
+      if (!envelope.ok || envelope.data === null) {
+        setPhase("error");
+        setOperationError(envelopeErrorMessage(envelope));
+        return;
+      }
+
+      setResources(sortResources(envelope.data.items));
+      setWarning(envelope.data.warning);
+      setPhase("ready");
+    } catch (error) {
+      setPhase("error");
+      setOperationError(error instanceof Error ? error.message : "Unknown list runtime error.");
+    }
+  }, [client]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const addMcp = useCallback(
+    async (input: AddMcpInput) => {
+      if (client === null) {
+        setFeedback({
+          kind: "error",
+          message: "Select a client before adding an MCP entry.",
+        });
+        return false;
+      }
+
+      const transport =
+        input.transport.kind === "stdio"
+          ? { command: input.transport.command, args: input.transport.args }
+          : { url: input.transport.url };
+
+      const sourcePathHint = resources.find((entry) => entry.source_path !== null)?.source_path;
+      const payload: Record<string, unknown> = {
+        transport,
+        enabled: input.enabled,
+      };
+      if (sourcePathHint !== null && sourcePathHint !== undefined) {
+        payload.source_path = sourcePathHint;
+      }
+
+      try {
+        const envelope = await mutateResource({
+          client,
+          resource_kind: "mcp",
+          action: "add",
+          target_id: input.targetId,
+          payload,
+        });
+
+        if (!envelope.ok || envelope.data === null) {
+          setFeedback({ kind: "error", message: envelopeErrorMessage(envelope) });
+          return false;
+        }
+
+        setFeedback({ kind: "success", message: envelope.data.message });
+        await refresh();
+        return true;
+      } catch (error) {
+        setFeedback({
+          kind: "error",
+          message: error instanceof Error ? error.message : "Unknown add runtime error.",
+        });
+        return false;
+      }
+    },
+    [client, refresh, resources],
+  );
+
+  const removeMcp = useCallback(
+    async (targetId: string, sourcePath: string | null) => {
+      if (client === null) {
+        setFeedback({
+          kind: "error",
+          message: "Select a client before removing an MCP entry.",
+        });
+        return false;
+      }
+
+      setPendingRemovalId(targetId);
+      try {
+        const envelope = await mutateResource({
+          client,
+          resource_kind: "mcp",
+          action: "remove",
+          target_id: targetId,
+          payload: sourcePath ? { source_path: sourcePath } : null,
+        });
+
+        if (!envelope.ok || envelope.data === null) {
+          setFeedback({ kind: "error", message: envelopeErrorMessage(envelope) });
+          return false;
+        }
+
+        setFeedback({ kind: "success", message: envelope.data.message });
+        await refresh();
+        return true;
+      } catch (error) {
+        setFeedback({
+          kind: "error",
+          message: error instanceof Error ? error.message : "Unknown remove runtime error.",
+        });
+        return false;
+      } finally {
+        setPendingRemovalId(null);
+      }
+    },
+    [client, refresh],
+  );
+
+  const sourcePathHint = useMemo(
+    () => resources.find((entry) => entry.source_path !== null)?.source_path ?? null,
+    [resources],
+  );
+
+  return {
+    phase,
+    resources,
+    warning,
+    operationError,
+    feedback,
+    pendingRemovalId,
+    sourcePathHint,
+    refresh,
+    addMcp,
+    removeMcp,
+    clearFeedback: () => setFeedback(null),
+  };
+}

--- a/tests/mcp-manager-panel.test.mjs
+++ b/tests/mcp-manager-panel.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const WORKSPACE_ROOT = new URL("..", import.meta.url);
+
+async function readWorkspaceFile(relativePath) {
+  return readFile(new URL(relativePath, WORKSPACE_ROOT), "utf8");
+}
+
+test("app shell renders the MCP manager route component", async () => {
+  const shellSource = await readWorkspaceFile("./src/features/app-shell/AppShell.tsx");
+
+  assert.match(shellSource, /McpManagerPanel/);
+  assert.match(shellSource, /route === "mcp"/);
+});
+
+test("mcp manager hook calls list and mutate commands", async () => {
+  const hookSource = await readWorkspaceFile("./src/features/mcp/useMcpManager.ts");
+
+  assert.match(hookSource, /listResources/);
+  assert.match(hookSource, /mutateResource/);
+  assert.match(hookSource, /action: "add"/);
+  assert.match(hookSource, /action: "remove"/);
+});


### PR DESCRIPTION
## Summary
- add a dedicated MCP manager panel in the app shell route
- implement MCP listing hook with refresh, warning/error handling, and deterministic sorting
- implement add/remove mutation flows with in-context feedback and remove confirmations
- add MCP add form with transport validation (`stdio` and `sse`)
- add MCP resource table with per-row remove actions and loading state
- add UI tests for MCP route wiring and command-hook integration

## Validation
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `pnpm exec biome check --write .`
- `pnpm run lint`
- `pnpm test`
- `cargo test --manifest-path src-tauri/Cargo.toml`

Closes #28