### PR TITLE
feat: implement Skills management tab with add/remove flows (issue #29)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -255,6 +255,15 @@ select {
   padding: 0.52rem 0.62rem;
 }
 
+.mcp-form textarea {
+  border-radius: 0.62rem;
+  border: 1px solid #bbcadc;
+  padding: 0.52rem 0.62rem;
+  font: inherit;
+  min-height: 8.2rem;
+  resize: vertical;
+}
+
 .checkbox-row {
   display: flex;
   align-items: center;

--- a/src/features/app-shell/AppShell.tsx
+++ b/src/features/app-shell/AppShell.tsx
@@ -6,6 +6,7 @@ import { ClientStatusCard } from "../clients/components/ClientStatusCard";
 import { useClientDetections } from "../clients/useClientDetections";
 import { ViewStatePanel } from "../common/ViewStatePanel";
 import { McpManagerPanel } from "../mcp/McpManagerPanel";
+import { SkillsManagerPanel } from "../skills/SkillsManagerPanel";
 import { type AppRoute, NAVIGATION_ITEMS } from "./navigation";
 
 function findSelectedDetection(
@@ -28,24 +29,7 @@ function renderRouteContent(route: AppRoute, selectedDetection: ClientDetection 
     return <McpManagerPanel client={selectedDetection?.client ?? null} />;
   }
 
-  if (selectedDetection === null) {
-    return (
-      <ViewStatePanel
-        title="Client Selection Required"
-        message="Select a detected client first to open this workspace."
-      />
-    );
-  }
-
-  return (
-    <section className="feature-placeholder">
-      <h2>Skills Manager</h2>
-      <p>
-        Selected client: <strong>{formatClientLabel(selectedDetection.client)}</strong>
-      </p>
-      <p>This route scaffold is ready. Interactive add/remove flows are tracked in issue #29.</p>
-    </section>
-  );
+  return <SkillsManagerPanel client={selectedDetection?.client ?? null} />;
 }
 
 export function AppShell() {

--- a/src/features/skills/SkillsManagerPanel.tsx
+++ b/src/features/skills/SkillsManagerPanel.tsx
@@ -1,0 +1,93 @@
+import type { ClientKind, ResourceRecord } from "../../backend/contracts";
+import { formatClientLabel } from "../clients/client-labels";
+import { ViewStatePanel } from "../common/ViewStatePanel";
+import { SkillAddForm } from "./components/SkillAddForm";
+import { SkillResourceTable } from "./components/SkillResourceTable";
+import { useSkillManager } from "./useSkillManager";
+
+interface SkillsManagerPanelProps {
+  client: ClientKind | null;
+}
+
+export function SkillsManagerPanel({ client }: SkillsManagerPanelProps) {
+  const {
+    phase,
+    resources,
+    warning,
+    operationError,
+    feedback,
+    pendingRemovalId,
+    addSkill,
+    removeSkill,
+    refresh,
+    clearFeedback,
+  } = useSkillManager(client);
+
+  async function handleRemove(resource: ResourceRecord) {
+    if (
+      !window.confirm(
+        `Remove Skill '${resource.display_name}' from ${formatClientLabel(resource.client)}?`,
+      )
+    ) {
+      return;
+    }
+
+    await removeSkill(resource.display_name, resource.source_path);
+  }
+
+  if (client === null) {
+    return (
+      <ViewStatePanel
+        title="Client Selection Required"
+        message="Select a client to list and mutate skill entries."
+      />
+    );
+  }
+
+  return (
+    <section className="mcp-panel">
+      <header className="mcp-header">
+        <div>
+          <h2>Skills Manager</h2>
+          <p>
+            Managing <strong>{formatClientLabel(client)}</strong>
+          </p>
+        </div>
+        <button
+          type="button"
+          className="ghost-button"
+          onClick={() => {
+            clearFeedback();
+            void refresh();
+          }}
+          disabled={phase === "loading"}
+        >
+          {phase === "loading" ? "Loading..." : "Reload Skills List"}
+        </button>
+      </header>
+
+      {warning ? <p className="mcp-feedback mcp-feedback-warning">{warning}</p> : null}
+      {operationError ? <p className="mcp-feedback mcp-feedback-error">{operationError}</p> : null}
+      {feedback ? (
+        <p
+          className={
+            feedback.kind === "success"
+              ? "mcp-feedback mcp-feedback-success"
+              : "mcp-feedback mcp-feedback-error"
+          }
+        >
+          {feedback.message}
+        </p>
+      ) : null}
+
+      <div className="mcp-layout">
+        <SkillAddForm disabled={phase === "loading"} onSubmit={addSkill} />
+        <SkillResourceTable
+          resources={resources}
+          pendingRemovalId={pendingRemovalId}
+          onRemove={handleRemove}
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/features/skills/components/SkillAddForm.tsx
+++ b/src/features/skills/components/SkillAddForm.tsx
@@ -1,0 +1,87 @@
+import { type FormEvent, useState } from "react";
+
+import type { AddSkillInput, SkillInstallInputKind } from "../useSkillManager";
+
+interface SkillAddFormProps {
+  disabled: boolean;
+  onSubmit: (input: AddSkillInput) => Promise<boolean>;
+}
+
+const DEFAULT_MANIFEST = `# New Skill
+
+Describe what this skill does and how to use it.
+`;
+
+export function SkillAddForm({ disabled, onSubmit }: SkillAddFormProps) {
+  const [targetId, setTargetId] = useState("new-skill");
+  const [installKind, setInstallKind] = useState<SkillInstallInputKind>("directory");
+  const [manifest, setManifest] = useState(DEFAULT_MANIFEST);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLocalError(null);
+
+    const normalizedTargetId = targetId.trim();
+    if (normalizedTargetId.length === 0) {
+      setLocalError("Target ID is required.");
+      return;
+    }
+
+    if (manifest.trim().length === 0) {
+      setLocalError("Manifest content is required.");
+      return;
+    }
+
+    const accepted = await onSubmit({
+      targetId: normalizedTargetId,
+      manifest,
+      installKind,
+    });
+
+    if (accepted) {
+      setTargetId("");
+    }
+  }
+
+  return (
+    <form className="mcp-form" onSubmit={(event) => void handleSubmit(event)}>
+      <h3>Add Skill Entry</h3>
+
+      {localError ? <p className="mcp-feedback mcp-feedback-error">{localError}</p> : null}
+
+      <label htmlFor="skill-target-id">Target ID</label>
+      <input
+        id="skill-target-id"
+        value={targetId}
+        onChange={(event) => setTargetId(event.currentTarget.value)}
+        placeholder="python-refactor"
+        disabled={disabled}
+      />
+
+      <label htmlFor="skill-install-kind">Install Kind</label>
+      <select
+        id="skill-install-kind"
+        value={installKind}
+        onChange={(event) => setInstallKind(event.currentTarget.value as SkillInstallInputKind)}
+        disabled={disabled}
+      >
+        <option value="directory">directory (target/SKILL.md)</option>
+        <option value="file">file (target.md)</option>
+      </select>
+
+      <label htmlFor="skill-manifest">SKILL.md Content</label>
+      <textarea
+        id="skill-manifest"
+        className="skills-markdown-input"
+        value={manifest}
+        onChange={(event) => setManifest(event.currentTarget.value)}
+        disabled={disabled}
+      />
+
+      <button className="ghost-button" type="submit" disabled={disabled}>
+        Add Skill
+      </button>
+    </form>
+  );
+}

--- a/src/features/skills/components/SkillResourceTable.tsx
+++ b/src/features/skills/components/SkillResourceTable.tsx
@@ -1,0 +1,66 @@
+import type { ResourceRecord } from "../../../backend/contracts";
+
+interface SkillResourceTableProps {
+  resources: ResourceRecord[];
+  pendingRemovalId: string | null;
+  onRemove: (resource: ResourceRecord) => Promise<void>;
+}
+
+function formatSourcePath(sourcePath: string | null): string {
+  return sourcePath ?? "Auto-resolved";
+}
+
+function formatInstallKind(value: string | null): string {
+  return value ?? "unknown";
+}
+
+export function SkillResourceTable({
+  resources,
+  pendingRemovalId,
+  onRemove,
+}: SkillResourceTableProps) {
+  if (resources.length === 0) {
+    return <p className="mcp-empty">No Skill entries registered for the selected client.</p>;
+  }
+
+  return (
+    <div className="mcp-table-wrapper">
+      <table className="mcp-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Install Kind</th>
+            <th>Enabled</th>
+            <th>Source</th>
+            <th aria-label="actions" />
+          </tr>
+        </thead>
+        <tbody>
+          {resources.map((resource) => {
+            const removing = pendingRemovalId === resource.display_name;
+            return (
+              <tr key={resource.id}>
+                <td>{resource.display_name}</td>
+                <td>{formatInstallKind(resource.install_kind)}</td>
+                <td>{resource.enabled ? "yes" : "no"}</td>
+                <td>{formatSourcePath(resource.source_path)}</td>
+                <td className="mcp-table-action-cell">
+                  <button
+                    type="button"
+                    className="ghost-button"
+                    onClick={() => {
+                      void onRemove(resource);
+                    }}
+                    disabled={removing}
+                  >
+                    {removing ? "Removing..." : "Remove"}
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/features/skills/useSkillManager.ts
+++ b/src/features/skills/useSkillManager.ts
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { listResources, mutateResource } from "../../backend/client";
+import type { ClientKind, CommandEnvelope, ResourceRecord } from "../../backend/contracts";
+
+export type SkillInstallInputKind = "directory" | "file";
+
+export interface AddSkillInput {
+  targetId: string;
+  manifest: string;
+  installKind: SkillInstallInputKind;
+}
+
+interface MutationFeedback {
+  kind: "success" | "error";
+  message: string;
+}
+
+type LoadPhase = "idle" | "loading" | "ready" | "error";
+
+interface UseSkillManagerResult {
+  phase: LoadPhase;
+  resources: ResourceRecord[];
+  warning: string | null;
+  operationError: string | null;
+  feedback: MutationFeedback | null;
+  pendingRemovalId: string | null;
+  refresh: () => Promise<void>;
+  addSkill: (input: AddSkillInput) => Promise<boolean>;
+  removeSkill: (targetId: string, sourcePath: string | null) => Promise<boolean>;
+  clearFeedback: () => void;
+}
+
+function envelopeErrorMessage(envelope: CommandEnvelope<unknown>): string {
+  if (envelope.error?.message) {
+    return envelope.error.message;
+  }
+  return "Command failed without an explicit error payload.";
+}
+
+function sortResources(resources: ResourceRecord[]): ResourceRecord[] {
+  return [...resources].sort((left, right) => {
+    if (left.display_name !== right.display_name) {
+      return left.display_name.localeCompare(right.display_name);
+    }
+    return left.id.localeCompare(right.id);
+  });
+}
+
+export function useSkillManager(client: ClientKind | null): UseSkillManagerResult {
+  const [phase, setPhase] = useState<LoadPhase>("idle");
+  const [resources, setResources] = useState<ResourceRecord[]>([]);
+  const [warning, setWarning] = useState<string | null>(null);
+  const [operationError, setOperationError] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<MutationFeedback | null>(null);
+  const [pendingRemovalId, setPendingRemovalId] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (client === null) {
+      setPhase("idle");
+      setResources([]);
+      setWarning(null);
+      setOperationError(null);
+      return;
+    }
+
+    setPhase("loading");
+    setOperationError(null);
+
+    try {
+      const envelope = await listResources({
+        client,
+        resource_kind: "skill",
+      });
+
+      if (!envelope.ok || envelope.data === null) {
+        setPhase("error");
+        setOperationError(envelopeErrorMessage(envelope));
+        return;
+      }
+
+      setResources(sortResources(envelope.data.items));
+      setWarning(envelope.data.warning);
+      setPhase("ready");
+    } catch (error) {
+      setPhase("error");
+      setOperationError(error instanceof Error ? error.message : "Unknown list runtime error.");
+    }
+  }, [client]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const addSkill = useCallback(
+    async (input: AddSkillInput) => {
+      if (client === null) {
+        setFeedback({
+          kind: "error",
+          message: "Select a client before adding a skill entry.",
+        });
+        return false;
+      }
+
+      try {
+        const envelope = await mutateResource({
+          client,
+          resource_kind: "skill",
+          action: "add",
+          target_id: input.targetId,
+          payload: {
+            manifest: input.manifest,
+            install_kind: input.installKind,
+          },
+        });
+
+        if (!envelope.ok || envelope.data === null) {
+          setFeedback({ kind: "error", message: envelopeErrorMessage(envelope) });
+          return false;
+        }
+
+        setFeedback({ kind: "success", message: envelope.data.message });
+        await refresh();
+        return true;
+      } catch (error) {
+        setFeedback({
+          kind: "error",
+          message: error instanceof Error ? error.message : "Unknown add runtime error.",
+        });
+        return false;
+      }
+    },
+    [client, refresh],
+  );
+
+  const removeSkill = useCallback(
+    async (targetId: string, sourcePath: string | null) => {
+      if (client === null) {
+        setFeedback({
+          kind: "error",
+          message: "Select a client before removing a skill entry.",
+        });
+        return false;
+      }
+
+      setPendingRemovalId(targetId);
+      try {
+        const envelope = await mutateResource({
+          client,
+          resource_kind: "skill",
+          action: "remove",
+          target_id: targetId,
+          payload: sourcePath ? { source_path: sourcePath } : null,
+        });
+
+        if (!envelope.ok || envelope.data === null) {
+          setFeedback({ kind: "error", message: envelopeErrorMessage(envelope) });
+          return false;
+        }
+
+        setFeedback({ kind: "success", message: envelope.data.message });
+        await refresh();
+        return true;
+      } catch (error) {
+        setFeedback({
+          kind: "error",
+          message: error instanceof Error ? error.message : "Unknown remove runtime error.",
+        });
+        return false;
+      } finally {
+        setPendingRemovalId(null);
+      }
+    },
+    [client, refresh],
+  );
+
+  return {
+    phase,
+    resources,
+    warning,
+    operationError,
+    feedback,
+    pendingRemovalId,
+    refresh,
+    addSkill,
+    removeSkill,
+    clearFeedback: () => setFeedback(null),
+  };
+}

--- a/tests/skills-manager-panel.test.mjs
+++ b/tests/skills-manager-panel.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const WORKSPACE_ROOT = new URL("..", import.meta.url);
+
+async function readWorkspaceFile(relativePath) {
+  return readFile(new URL(relativePath, WORKSPACE_ROOT), "utf8");
+}
+
+test("app shell renders the skills manager route component", async () => {
+  const shellSource = await readWorkspaceFile("./src/features/app-shell/AppShell.tsx");
+
+  assert.match(shellSource, /SkillsManagerPanel/);
+  assert.match(shellSource, /route === "mcp"/);
+});
+
+test("skills manager hook calls list and mutate commands", async () => {
+  const hookSource = await readWorkspaceFile("./src/features/skills/useSkillManager.ts");
+
+  assert.match(hookSource, /listResources/);
+  assert.match(hookSource, /mutateResource/);
+  assert.match(hookSource, /resource_kind: "skill"/);
+  assert.match(hookSource, /action: "add"/);
+  assert.match(hookSource, /action: "remove"/);
+});


### PR DESCRIPTION
## Summary
- add a dedicated Skills manager panel in the app shell route
- implement Skills listing hook with refresh, warning/error handling, and deterministic sorting
- implement add/remove mutation flows with in-context feedback and remove confirmations
- add Skills add form with install-kind and manifest input validation
- add Skills resource table with per-row remove actions and loading state
- add UI tests for Skills route wiring and command-hook integration

## Validation
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `pnpm exec biome check --write .`
- `pnpm run lint`
- `pnpm test`
- `cargo test --manifest-path src-tauri/Cargo.toml`

Closes #29