### PR TITLE
feat(release): add macOS DMG packaging pipeline

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -1,0 +1,53 @@
+name: macOS DMG Packaging
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  package-macos-dmg:
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build DMG package
+        run: pnpm run package:macos:dmg
+
+      - name: Verify packaging outputs
+        run: |
+          ls -la src-tauri/target/release/bundle/dmg
+          test -f dist/macos/dmg-manifest.json
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ai-manager-macos-dmg
+          path: src-tauri/target/release/bundle/dmg/*.dmg
+          if-no-files-found: error
+
+      - name: Upload packaging manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: ai-manager-macos-dmg-manifest
+          path: dist/macos/dmg-manifest.json
+          if-no-files-found: error

--- a/docs/release/macos-packaging.md
+++ b/docs/release/macos-packaging.md
@@ -1,0 +1,50 @@
+# macOS DMG Packaging
+
+This project provides a reproducible macOS-first packaging pipeline that generates a DMG artifact
+and a checksum manifest.
+
+## Prerequisites
+
+- macOS host (Apple Silicon or Intel)
+- Node.js `v24`
+- `pnpm` `10.30.3`
+- Rust stable toolchain
+- Xcode Command Line Tools installed
+
+## Clean-Machine Packaging Steps
+
+1. Install dependencies:
+   - `pnpm install --frozen-lockfile`
+2. Build and package:
+   - `pnpm run package:macos:dmg`
+3. Verify outputs:
+   - DMG artifact directory: `src-tauri/target/release/bundle/dmg/`
+   - Packaging manifest: `dist/macos/dmg-manifest.json`
+
+The manifest includes:
+- artifact file name
+- relative output path
+- byte size
+- SHA256 hash
+- product metadata from `tauri.conf.json`
+
+## Pre-release Sanity Checks
+
+1. Mount DMG and copy `AI Manager.app` into `/Applications`.
+2. Launch once from terminal:
+   - `open /Applications/AI\\ Manager.app`
+3. Verify application boot:
+   - App shell renders
+   - Supported client cards are visible
+   - No immediate crash on startup
+4. Confirm artifact metadata:
+   - Compare local DMG SHA256 with `dist/macos/dmg-manifest.json`
+
+## CI Pipeline
+
+The workflow [`.github/workflows/macos-dmg.yml`](../../.github/workflows/macos-dmg.yml) runs on
+`macos-14` and:
+
+- executes `pnpm run package:macos:dmg`
+- validates DMG and manifest outputs exist
+- uploads DMG and manifest as build artifacts

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
+    "package:macos:dmg": "node ./scripts/package-macos-dmg.mjs",
     "test": "node --test"
   },
   "dependencies": {

--- a/scripts/package-macos-dmg.mjs
+++ b/scripts/package-macos-dmg.mjs
@@ -1,0 +1,108 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const workspaceRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const tauriConfigPath = path.join(workspaceRoot, "src-tauri", "tauri.conf.json");
+const dmgOutputDir = path.join(workspaceRoot, "src-tauri", "target", "release", "bundle", "dmg");
+const manifestOutputPath = path.join(workspaceRoot, "dist", "macos", "dmg-manifest.json");
+
+async function main() {
+  if (process.platform !== "darwin") {
+    throw new Error("macOS packaging is only supported on darwin hosts.");
+  }
+
+  await runCommand("pnpm", ["run", "ensure:tauri-icon"]);
+  await runCommand("pnpm", ["exec", "tauri", "build", "--bundles", "dmg"]);
+
+  const dmgArtifact = await findLatestDmgArtifact(dmgOutputDir);
+  const artifactStats = await stat(dmgArtifact.absolutePath);
+  const sha256 = await sha256File(dmgArtifact.absolutePath);
+  const tauriConfig = await loadTauriConfig(tauriConfigPath);
+
+  const manifest = {
+    generated_at_iso: new Date().toISOString(),
+    product_name: tauriConfig.productName,
+    identifier: tauriConfig.identifier,
+    artifact: {
+      file_name: dmgArtifact.fileName,
+      relative_path: path.relative(workspaceRoot, dmgArtifact.absolutePath),
+      bytes: artifactStats.size,
+      sha256,
+    },
+  };
+
+  await mkdir(path.dirname(manifestOutputPath), { recursive: true });
+  await writeFile(manifestOutputPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+  console.log(`DMG packaged: ${manifest.artifact.relative_path}`);
+  console.log(`Manifest written: ${path.relative(workspaceRoot, manifestOutputPath)}`);
+}
+
+async function runCommand(command, args) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: workspaceRoot,
+      stdio: "inherit",
+      env: process.env,
+    });
+
+    child.on("error", (error) => reject(error));
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(new Error(`Command failed with exit code ${code}: ${command} ${args.join(" ")}`));
+    });
+  });
+}
+
+async function findLatestDmgArtifact(outputDir) {
+  const entries = await readdir(outputDir, { withFileTypes: true });
+  const dmgFiles = entries.filter((entry) => entry.isFile() && entry.name.endsWith(".dmg"));
+  if (dmgFiles.length === 0) {
+    throw new Error(`No DMG artifact found under '${outputDir}'.`);
+  }
+
+  const withStats = await Promise.all(
+    dmgFiles.map(async (entry) => {
+      const absolutePath = path.join(outputDir, entry.name);
+      const details = await stat(absolutePath);
+      return {
+        fileName: entry.name,
+        absolutePath,
+        modifiedMs: details.mtimeMs,
+      };
+    }),
+  );
+
+  withStats.sort((left, right) => right.modifiedMs - left.modifiedMs);
+  return withStats[0];
+}
+
+async function sha256File(filePath) {
+  const hash = createHash("sha256");
+  const stream = createReadStream(filePath);
+
+  await new Promise((resolve, reject) => {
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", resolve);
+    stream.on("error", reject);
+  });
+
+  return hash.digest("hex");
+}
+
+async function loadTauriConfig(configPath) {
+  const payload = await readFile(configPath, "utf8");
+  return JSON.parse(payload);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,6 +22,6 @@
     }
   },
   "bundle": {
-    "active": false
+    "active": true
   }
 }

--- a/tests/macos-packaging.test.mjs
+++ b/tests/macos-packaging.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const WORKSPACE_ROOT = new URL("..", import.meta.url);
+
+async function readWorkspaceFile(relativePath) {
+  return readFile(new URL(relativePath, WORKSPACE_ROOT), "utf8");
+}
+
+test("package scripts expose macos dmg build entrypoint", async () => {
+  const payload = await readWorkspaceFile("./package.json");
+  const packageJson = JSON.parse(payload);
+
+  assert.equal(packageJson.scripts["package:macos:dmg"], "node ./scripts/package-macos-dmg.mjs");
+});
+
+test("macos packaging script builds dmg and writes manifest", async () => {
+  const source = await readWorkspaceFile("./scripts/package-macos-dmg.mjs");
+
+  assert.match(source, /tauri", "build", "--bundles", "dmg"/);
+  assert.match(source, /dmg-manifest\.json/);
+  assert.match(source, /sha256/);
+});
+
+test("macos dmg workflow uses mac runner and uploads artifacts", async () => {
+  const workflow = await readWorkspaceFile("./.github/workflows/macos-dmg.yml");
+
+  assert.match(workflow, /runs-on: macos-14/);
+  assert.match(workflow, /pnpm run package:macos:dmg/);
+  assert.match(workflow, /actions\/upload-artifact@v4/);
+  assert.match(workflow, /ai-manager-macos-dmg-manifest/);
+});
+
+test("packaging docs include clean-machine steps and launch check", async () => {
+  const docs = await readWorkspaceFile("./docs/release/macos-packaging.md");
+
+  assert.match(docs, /pnpm run package:macos:dmg/);
+  assert.match(docs, /dmg-manifest\.json/);
+  assert.match(docs, /open \/Applications\/AI\\\\ Manager\.app/);
+});


### PR DESCRIPTION
## Summary
- add a reproducible macOS DMG packaging workflow for CI and local builds
- add `package:macos:dmg` script that builds a DMG and writes a checksum manifest
- document clean-machine packaging and pre-release sanity checks
- add contract tests for packaging script/workflow/docs

## Validation
- pnpm run lint
- pnpm test
- cargo test --manifest-path src-tauri/Cargo.toml

Closes #33