### PR TITLE
docs(release): add release checklist and versioning policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Tauri 2 + React/TypeScript desktop foundation for managing MCP and Skills across
 - `src-tauri/src/application/`: Use-case service layer consumed by commands.
 - `docs/spec/`: MVP requirements and contracts.
 - `docs/architecture/`: Module boundary and design documentation.
+- `docs/release/`: Packaging, release checklist, and versioning policy.
 - `schemas/`: JSON schema contracts for specs.
 - `tests/`: Node.js unit tests for spec and project contracts.
 

--- a/docs/release/release-checklist.md
+++ b/docs/release/release-checklist.md
@@ -1,0 +1,42 @@
+# Release Checklist v1
+
+This checklist standardizes release gating for issue `#34`.
+
+## Release Readiness Rule
+
+- Decision: `go` only if every blocking item below is complete with evidence.
+- Evidence types:
+  - `automated_test`
+  - `artifact_validation`
+  - `manual_smoke`
+  - `release_notes_review`
+
+## Blocking Checklist
+
+1. Quality gate: `pnpm run ci` passes on `main`.
+   - Evidence: CI run URL and successful status.
+2. Packaging gate: macOS DMG workflow succeeds.
+   - Evidence: `.dmg` artifact and `dist/macos/dmg-manifest.json`.
+3. Install/launch smoke gate: packaged app installs and launches on macOS.
+   - Evidence: manual log with install path and launch confirmation.
+4. Contract stability gate: no unintended breaking schema changes.
+   - Evidence: diff review for files in `docs/spec/*.v1.json` and `schemas/*.schema.json`.
+5. Release communication gate: release notes are prepared from template.
+   - Evidence: completed notes using `docs/release/release-notes-template.md`.
+
+## Release Execution Steps
+
+1. Confirm all blocking checklist items are complete.
+2. Determine next version using `docs/release/versioning-policy.md`.
+3. Create release notes from template and include:
+   - highlights
+   - compatibility notes
+   - known issues
+4. Create git tag `vX.Y.Z`.
+5. Publish release artifacts and notes.
+
+## Post-release Validation
+
+1. Install latest DMG on a clean macOS account.
+2. Verify client detection and list flows still work.
+3. Archive release evidence links in the release ticket.

--- a/docs/release/release-notes-template.md
+++ b/docs/release/release-notes-template.md
@@ -1,0 +1,49 @@
+# Release Notes Template
+
+Use this template for every `vX.Y.Z` release.
+
+## Title
+
+- `AI Manager vX.Y.Z`
+- Release date: `YYYY-MM-DD`
+
+## Summary
+
+- One paragraph summarizing scope and intent.
+
+## Highlights
+
+- `feature/change 1`
+- `feature/change 2`
+- `feature/change 3`
+
+## Compatibility
+
+- Supported clients:
+  - Claude Code
+  - Codex CLI
+  - Cursor
+  - Codex App
+- Platform support:
+  - macOS
+
+## Upgrade and Migration Notes
+
+- Breaking changes: `none` or describe required actions.
+- Config migration steps (if any).
+- Rollback guidance (if needed).
+
+## Fixes and Reliability
+
+- Notable bug fixes.
+- Stability and security hardening updates.
+
+## Known Issues
+
+- `issue or limitation 1`
+- `issue or limitation 2`
+
+## Artifacts
+
+- DMG artifact name and checksum from `dist/macos/dmg-manifest.json`.
+- Related CI run links.

--- a/docs/release/versioning-policy.md
+++ b/docs/release/versioning-policy.md
@@ -1,0 +1,47 @@
+# Versioning Policy v1
+
+This project uses semantic versioning for issue `#34`.
+
+## Version Format
+
+- Stable format: `MAJOR.MINOR.PATCH`
+- Optional pre-release format: `MAJOR.MINOR.PATCH-rc.N`
+
+## Deterministic Increment Rules
+
+1. Bump `MAJOR` when any change is backward-incompatible for users or integrators.
+   - Examples:
+     - remove or rename Tauri command contracts
+     - incompatible schema changes under `schemas/`
+     - remove support for a previously supported client
+2. Bump `MINOR` when adding backward-compatible capabilities.
+   - Examples:
+     - new non-breaking fields in responses
+     - new optional UI flows
+     - additional backward-compatible adapters
+3. Bump `PATCH` for backward-compatible fixes and docs-only updates.
+   - Examples:
+     - bug fixes without contract breaks
+     - performance/stability improvements
+     - test-only or documentation-only corrections
+
+## Release Candidate Rules
+
+- Use `-rc.N` only for release validation builds.
+- `N` increments by 1 for each candidate cut from the same target version.
+- Final release removes `-rc.N` without changing `MAJOR.MINOR.PATCH`.
+
+## Change Classification Checklist
+
+1. Does this release break existing behavior or contracts?
+   - yes: `MAJOR`
+2. Does this release add backward-compatible functionality?
+   - yes: `MINOR`
+3. Otherwise:
+   - `PATCH`
+
+## Required Artifacts
+
+- Updated version in project metadata.
+- Completed checklist in `docs/release/release-checklist.md`.
+- Notes generated from `docs/release/release-notes-template.md`.

--- a/tests/release-governance.test.mjs
+++ b/tests/release-governance.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const WORKSPACE_ROOT = new URL("..", import.meta.url);
+
+async function readWorkspaceFile(relativePath) {
+  return readFile(new URL(relativePath, WORKSPACE_ROOT), "utf8");
+}
+
+test("release checklist defines blocking gates and evidence", async () => {
+  const checklist = await readWorkspaceFile("./docs/release/release-checklist.md");
+
+  assert.match(checklist, /Decision: `go` only if every blocking item/);
+  assert.match(checklist, /pnpm run ci/);
+  assert.match(checklist, /macOS DMG workflow succeeds/);
+  assert.match(checklist, /release-notes-template\.md/);
+});
+
+test("versioning policy defines deterministic major/minor/patch rules", async () => {
+  const policy = await readWorkspaceFile("./docs/release/versioning-policy.md");
+
+  assert.match(policy, /semantic versioning/);
+  assert.match(policy, /Bump `MAJOR`/);
+  assert.match(policy, /Bump `MINOR`/);
+  assert.match(policy, /Bump `PATCH`/);
+  assert.match(policy, /Change Classification Checklist/);
+});
+
+test("release notes template includes communication sections", async () => {
+  const template = await readWorkspaceFile("./docs/release/release-notes-template.md");
+
+  assert.match(template, /## Summary/);
+  assert.match(template, /## Compatibility/);
+  assert.match(template, /## Upgrade and Migration Notes/);
+  assert.match(template, /## Known Issues/);
+  assert.match(template, /dist\/macos\/dmg-manifest\.json/);
+});
+
+test("readme indexes release documentation directory", async () => {
+  const readme = await readWorkspaceFile("./README.md");
+
+  assert.match(readme, /`docs\/release\/`: Packaging, release checklist, and versioning policy\./);
+});


### PR DESCRIPTION
## Summary
- add deterministic release checklist for go/no-go decisions
- add semantic versioning policy with major/minor/patch classification rules
- add release notes template for consistent communication
- add contract test coverage for release governance docs

## Validation
- pnpm run lint
- pnpm test
- cargo test --manifest-path src-tauri/Cargo.toml

Closes #34