### PR TITLE
docs(operations): add config, backup, and troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Tauri 2 + React/TypeScript desktop foundation for managing MCP and Skills across
 - `docs/spec/`: MVP requirements and contracts.
 - `docs/architecture/`: Module boundary and design documentation.
 - `docs/release/`: Packaging, release checklist, and versioning policy.
+- `docs/operations/`: Config path, backup, and troubleshooting playbooks.
 - `schemas/`: JSON schema contracts for specs.
 - `tests/`: Node.js unit tests for spec and project contracts.
 

--- a/docs/operations/config-backup-troubleshooting.md
+++ b/docs/operations/config-backup-troubleshooting.md
@@ -1,0 +1,97 @@
+# Operations Guide: Config Paths, Backup, and Troubleshooting
+
+This guide documents real application behavior for issue `#35`.
+
+## Config Locations and Overrides (macOS-first)
+
+### MCP config paths
+
+- Claude Code:
+  - Override: `AI_MANAGER_CLAUDE_CODE_MCP_CONFIG`
+  - Fallback: `~/.claude/claude_code_config.json`
+- Codex CLI:
+  - Override: `AI_MANAGER_CODEX_CLI_MCP_CONFIG`
+  - Fallback: `~/.codex/config.toml`
+- Cursor:
+  - Override: `AI_MANAGER_CURSOR_MCP_CONFIG`
+  - Fallback order:
+    - `~/.cursor/mcp.json`
+    - `~/Library/Application Support/Cursor/User/mcp.json`
+- Codex App:
+  - Override: `AI_MANAGER_CODEX_APP_MCP_CONFIG`
+  - Fallback order:
+    - `~/Library/Application Support/Codex/mcp.json`
+    - `~/.config/Codex/mcp.json`
+
+### Skills directory paths
+
+- Claude Code:
+  - Override: `AI_MANAGER_CLAUDE_CODE_SKILLS_DIR`
+  - Fallback: `~/.claude/skills`
+- Codex CLI:
+  - Override: `AI_MANAGER_CODEX_CLI_SKILLS_DIR`
+  - Fallback: `~/.codex/skills`
+- Cursor:
+  - Override: `AI_MANAGER_CURSOR_SKILLS_DIR`
+  - Fallback order:
+    - `~/.cursor/skills`
+    - `~/Library/Application Support/Cursor/User/skills`
+- Codex App:
+  - Override: `AI_MANAGER_CODEX_APP_SKILLS_DIR`
+  - Fallback order:
+    - `~/Library/Application Support/Codex/skills`
+    - `~/.config/Codex/skills`
+
+## Backup and Restore Procedure
+
+Before file mutation, the app creates backup artifacts for existing targets.
+
+- Backup directory: sibling directory named `.ai-manager-backups`
+- Backup naming: `<filename>.<timestamp_ms>.bak`
+- Backup creation condition: target file already exists
+- Rollback behavior:
+  - If original file existed, backup is copied back
+  - If original file did not exist, newly created file is removed
+
+### How to restore
+
+When action feedback includes `Backup: ...` and `Source: ...`, restore with:
+
+```bash
+cp "<backup_path>" "<target_path>"
+```
+
+If only `Backup: ...` is visible, use the client path mapping above to determine the target path.
+
+## Troubleshooting Playbook
+
+### Detection failures
+
+- `[config_override_missing]`: override env path points to a missing file
+  - Check env var value and file existence
+- `[config_permission_denied]`: config exists but is unreadable
+  - Fix read permissions for the current user
+- `[binary_missing]`: CLI binary not found in `PATH`
+  - Install client or update `PATH`
+- `[binary_and_config_missing]`: neither executable nor config was resolved
+  - Verify installation and default config locations
+
+### Parse and list failures
+
+- `Invalid JSON MCP config: ...`
+  - Fix syntax in JSON config and retry
+- `Invalid TOML MCP config: ...`
+  - Fix syntax in TOML config and retry
+- Permission or I/O failures while reading config
+  - Verify path existence and read permission
+
+### Mutation failures
+
+- `MCP '<id>' already exists.` / `MCP '<id>' does not exist.`
+  - Use list flow first, then re-run add/remove
+- `Skill '<id>' already exists. Conflicts: ...`
+  - Remove conflict target or choose a different id
+- `source_path '<...>' does not exist.`
+  - Correct the path and retry
+- Internal mutation failure with `rollback_succeeded=true`
+  - Mutation was reverted; inspect source config and backup, then retry

--- a/tests/operator-docs.test.mjs
+++ b/tests/operator-docs.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const WORKSPACE_ROOT = new URL("..", import.meta.url);
+
+async function readWorkspaceFile(relativePath) {
+  return readFile(new URL(relativePath, WORKSPACE_ROOT), "utf8");
+}
+
+test("operations doc covers all MCP and skills override environment variables", async () => {
+  const operationsDoc = await readWorkspaceFile(
+    "./docs/operations/config-backup-troubleshooting.md",
+  );
+
+  const sources = await Promise.all([
+    readWorkspaceFile("./src-tauri/src/detection/clients/claude_code.rs"),
+    readWorkspaceFile("./src-tauri/src/detection/clients/codex_cli.rs"),
+    readWorkspaceFile("./src-tauri/src/detection/clients/cursor.rs"),
+    readWorkspaceFile("./src-tauri/src/detection/clients/codex_app.rs"),
+    readWorkspaceFile("./src-tauri/src/application/skill_path_resolver.rs"),
+  ]);
+
+  const variables = new Set(
+    sources
+      .flatMap((source) => source.match(/AI_MANAGER_[A-Z0-9_]+/g) ?? [])
+      .filter((name) => name.endsWith("_MCP_CONFIG") || name.endsWith("_SKILLS_DIR")),
+  );
+
+  assert.equal(variables.size, 8);
+
+  for (const variable of variables) {
+    assert.match(operationsDoc, new RegExp(variable));
+  }
+});
+
+test("operations doc path mapping matches macOS fallback paths used by code", async () => {
+  const operationsDoc = await readWorkspaceFile(
+    "./docs/operations/config-backup-troubleshooting.md",
+  );
+  const expectedPaths = [
+    "~/.claude/claude_code_config.json",
+    "~/.codex/config.toml",
+    "~/.cursor/mcp.json",
+    "~/Library/Application Support/Cursor/User/mcp.json",
+    "~/Library/Application Support/Codex/mcp.json",
+    "~/.config/Codex/mcp.json",
+    "~/.claude/skills",
+    "~/.codex/skills",
+    "~/.cursor/skills",
+    "~/Library/Application Support/Cursor/User/skills",
+    "~/Library/Application Support/Codex/skills",
+    "~/.config/Codex/skills",
+  ];
+
+  for (const pathValue of expectedPaths) {
+    assert.match(operationsDoc, new RegExp(escapeForRegExp(pathValue)));
+  }
+});
+
+test("operations doc backup and restore section aligns with mutation implementation", async () => {
+  const operationsDoc = await readWorkspaceFile(
+    "./docs/operations/config-backup-troubleshooting.md",
+  );
+  const backupManagerSource = await readWorkspaceFile(
+    "./src-tauri/src/infra/mutation/backup_manager.rs",
+  );
+  const diagnosticsSource = await readWorkspaceFile("./src/features/common/errorDiagnostics.ts");
+
+  assert.match(backupManagerSource, /\.ai-manager-backups/);
+  assert.match(backupManagerSource, /\{\}\.\{\}\.bak/);
+  assert.match(diagnosticsSource, /Restore if needed: cp/);
+
+  assert.match(operationsDoc, /\.ai-manager-backups/);
+  assert.match(operationsDoc, /<filename>\.<timestamp_ms>\.bak/);
+  assert.match(operationsDoc, /cp "<backup_path>" "<target_path>"/);
+});
+
+test("operations doc includes actionable troubleshooting patterns for current error flows", async () => {
+  const operationsDoc = await readWorkspaceFile(
+    "./docs/operations/config-backup-troubleshooting.md",
+  );
+
+  assert.match(operationsDoc, /\[config_override_missing\]/);
+  assert.match(operationsDoc, /\[config_permission_denied\]/);
+  assert.match(operationsDoc, /\[binary_missing\]/);
+  assert.match(operationsDoc, /Invalid JSON MCP config/);
+  assert.match(operationsDoc, /Invalid TOML MCP config/);
+  assert.match(operationsDoc, /rollback_succeeded=true/);
+});
+
+function escapeForRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary
- add operations guide for config paths and environment overrides per supported client
- document backup artifact layout and restore procedure aligned with current mutation behavior
- add troubleshooting playbook for detection/parse/mutation failures
- add tests that keep operations docs synchronized with implementation constants

## Validation
- pnpm run lint
- pnpm test
- cargo test --manifest-path src-tauri/Cargo.toml

Closes #35