### PR TITLE
test(policy): phase 3 - harden release governance checks against wording drift

### DIFF
--- a/tests/release-governance.test.mjs
+++ b/tests/release-governance.test.mjs
@@ -8,37 +8,111 @@ async function readWorkspaceFile(relativePath) {
   return readFile(new URL(relativePath, WORKSPACE_ROOT), "utf8");
 }
 
+function normalize(text) {
+  return text.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function parseMarkdownSections(markdown) {
+  const lines = markdown.split("\n");
+  const sections = new Map();
+  let currentHeading = null;
+  let currentLines = [];
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^##\s+(.+)$/);
+    if (headingMatch) {
+      if (currentHeading !== null) {
+        sections.set(currentHeading, currentLines.join("\n"));
+      }
+      currentHeading = normalize(headingMatch[1]);
+      currentLines = [];
+      continue;
+    }
+
+    if (currentHeading !== null) {
+      currentLines.push(line);
+    }
+  }
+
+  if (currentHeading !== null) {
+    sections.set(currentHeading, currentLines.join("\n"));
+  }
+
+  return sections;
+}
+
+function assertContainsTokens(text, tokens, label) {
+  const normalized = normalize(text);
+  for (const token of tokens) {
+    assert.ok(
+      normalized.includes(normalize(token)),
+      `${label} is missing required token: ${token}`,
+    );
+  }
+}
+
 test("release checklist defines blocking gates and evidence", async () => {
   const checklist = await readWorkspaceFile("./docs/release/release-checklist.md");
+  const sections = parseMarkdownSections(checklist);
 
-  assert.match(checklist, /Decision: `go` only if every blocking item/);
-  assert.match(checklist, /pnpm run ci/);
-  assert.match(checklist, /macOS DMG workflow succeeds/);
-  assert.match(checklist, /release-notes-template\.md/);
+  assert.ok(sections.has("release readiness rule"));
+  assert.ok(sections.has("blocking checklist"));
+
+  assertContainsTokens(
+    sections.get("release readiness rule"),
+    ["decision", "go", "blocking", "evidence"],
+    "release readiness rule",
+  );
+  assertContainsTokens(
+    sections.get("blocking checklist"),
+    ["pnpm run ci", "macos dmg", "dmg-manifest.json", "release-notes-template.md"],
+    "blocking checklist",
+  );
 });
 
 test("versioning policy defines deterministic major/minor/patch rules", async () => {
   const policy = await readWorkspaceFile("./docs/release/versioning-policy.md");
+  const sections = parseMarkdownSections(policy);
 
-  assert.match(policy, /semantic versioning/);
-  assert.match(policy, /Bump `MAJOR`/);
-  assert.match(policy, /Bump `MINOR`/);
-  assert.match(policy, /Bump `PATCH`/);
-  assert.match(policy, /Change Classification Checklist/);
+  assertContainsTokens(policy, ["semantic versioning"], "versioning policy");
+  assert.ok(sections.has("deterministic increment rules"));
+  assert.ok(sections.has("change classification checklist"));
+
+  assertContainsTokens(
+    sections.get("deterministic increment rules"),
+    ["major", "minor", "patch"],
+    "deterministic increment rules",
+  );
 });
 
 test("release notes template includes communication sections", async () => {
   const template = await readWorkspaceFile("./docs/release/release-notes-template.md");
+  const sections = parseMarkdownSections(template);
+  const sectionNames = new Set(sections.keys());
 
-  assert.match(template, /## Summary/);
-  assert.match(template, /## Compatibility/);
-  assert.match(template, /## Upgrade and Migration Notes/);
-  assert.match(template, /## Known Issues/);
-  assert.match(template, /dist\/macos\/dmg-manifest\.json/);
+  assert.ok(sectionNames.has("summary"));
+  assert.ok(sectionNames.has("compatibility"));
+  assert.ok(sectionNames.has("upgrade and migration notes"));
+  assert.ok(sectionNames.has("known issues"));
+  assert.ok(sectionNames.has("artifacts"));
+
+  assertContainsTokens(
+    sections.get("artifacts"),
+    ["dist/macos/dmg-manifest.json"],
+    "release notes artifacts section",
+  );
 });
 
 test("readme indexes release documentation directory", async () => {
   const readme = await readWorkspaceFile("./README.md");
+  const releaseDocsLine = readme
+    .split("\n")
+    .find((line) => line.toLowerCase().includes("`docs/release/`"));
 
-  assert.match(readme, /`docs\/release\/`: Packaging, release checklist, and versioning policy\./);
+  assert.ok(releaseDocsLine, "README must include docs/release index line");
+  assertContainsTokens(
+    releaseDocsLine,
+    ["packaging", "release checklist", "versioning policy"],
+    "README docs/release index line",
+  );
 });


### PR DESCRIPTION
## Summary
This phase refactors `tests/release-governance.test.mjs` to reduce wording sensitivity while preserving governance intent coverage.

## What changed
- Added markdown section parsing helpers (`parseMarkdownSections`) and normalized token matching.
- Replaced brittle exact regex assertions with:
  - required section presence checks
  - required governance token checks inside specific sections
- Kept existing intent coverage for:
  - release checklist go/no-go + evidence and artifact linkage
  - versioning major/minor/patch and classification guidance
  - release note template required sections and artifact path
  - README release-docs indexing

## Validation
- `pnpm run test:policy`
- `pnpm run lint`
- `pnpm test`
- `pnpm outdated` (no outdated dependencies reported)

Closes #64