### PR TITLE
refactor(infra): rewrite adapters/parsers/security imports to infra namespace

### DIFF
--- a/src-tauri/src/adapters.rs
+++ b/src-tauri/src/adapters.rs
@@ -1,1 +1,0 @@
-pub use crate::infra::adapters::*;

--- a/src-tauri/src/application/critical_paths_suite.rs
+++ b/src-tauri/src/application/critical_paths_suite.rs
@@ -13,7 +13,7 @@ use super::{
 use crate::{
     contracts::{common::ClientKind, mutate::MutationAction},
     detection::DetectorRegistry,
-    parsers::{ParseOutcome, ParserRegistry},
+    infra::parsers::{ParseOutcome, ParserRegistry},
 };
 
 #[derive(Debug, Deserialize)]

--- a/src-tauri/src/contracts/command.rs
+++ b/src-tauri/src/contracts/command.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::common::LifecycleSnapshot;
-use crate::security::redaction::redact_sensitive_text;
+use crate::infra::security::redaction::redact_sensitive_text;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]

--- a/src-tauri/src/contracts/detect.rs
+++ b/src-tauri/src/contracts/detect.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::common::ClientKind;
-use crate::security::redaction::redact_sensitive_text;
+use crate::infra::security::redaction::redact_sensitive_text;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct DetectClientsRequest {

--- a/src-tauri/src/contracts/list.rs
+++ b/src-tauri/src/contracts/list.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::common::{ClientKind, ResourceKind};
-use crate::security::redaction::redact_sensitive_text;
+use crate::infra::security::redaction::redact_sensitive_text;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ListResourcesRequest {

--- a/src-tauri/src/contracts/mutate.rs
+++ b/src-tauri/src/contracts/mutate.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::common::{ClientKind, ResourceKind};
-use crate::security::redaction::redact_sensitive_text;
+use crate::infra::security::redaction::redact_sensitive_text;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/src-tauri/src/infra/mod.rs
+++ b/src-tauri/src/infra/mod.rs
@@ -1,8 +1,8 @@
 pub mod adapters;
-mod adapter_registry;
 mod mutation;
 pub mod parsers;
+pub mod registry;
 pub mod security;
 
-pub use adapter_registry::AdapterRegistry;
+pub use registry::AdapterRegistry;
 pub use mutation::{MutationTestHooks, SafeFileMutator};

--- a/src-tauri/src/infra/registry/adapter_registry.rs
+++ b/src-tauri/src/infra/registry/adapter_registry.rs
@@ -1,7 +1,7 @@
 use crate::{
-    adapters::{ClaudeCodeAdapter, CodexAppAdapter, CodexCliAdapter, CursorAdapter},
     contracts::common::ClientKind,
     domain::ClientAdapter,
+    infra::adapters::{ClaudeCodeAdapter, CodexAppAdapter, CodexCliAdapter, CursorAdapter},
 };
 
 pub struct AdapterRegistry {

--- a/src-tauri/src/infra/registry/mod.rs
+++ b/src-tauri/src/infra/registry/mod.rs
@@ -1,0 +1,3 @@
+mod adapter_registry;
+
+pub use adapter_registry::AdapterRegistry;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,12 +1,9 @@
-mod adapters;
 mod application;
 mod commands;
 mod contracts;
 mod detection;
 mod domain;
 mod infra;
-pub mod parsers;
-mod security;
 mod state;
 
 use commands::{detect_clients, discover_skill_repository, list_resources, mutate_resource};

--- a/src-tauri/src/parsers.rs
+++ b/src-tauri/src/parsers.rs
@@ -1,1 +1,0 @@
-pub use crate::infra::parsers::*;

--- a/src-tauri/src/security.rs
+++ b/src-tauri/src/security.rs
@@ -1,1 +1,0 @@
-pub use crate::infra::security::*;


### PR DESCRIPTION
## Summary
- rewrite remaining `adapters/parsers/security` references to `crate::infra::*` paths
- move `infra/adapter_registry.rs` to `infra/registry/adapter_registry.rs`
- add `infra/registry/mod.rs` and route `AdapterRegistry` export via `infra::registry`
- remove temporary compatibility shims introduced in #78 (`adapters.rs`, `parsers.rs`, `security.rs`)
- remove no-longer-needed root module declarations in `lib.rs`

## Issue
- closes #79
- part of #72
- tracked by #70

## Verification
- `cargo check` (pass)
- `cargo test` (pass)
- `pnpm run lint` (pass)
- `pnpm test` (pass)
- `pnpm outdated` (pass; no outdated packages listed)

## Notes
- `application/mcp/listing_service.rs` was slightly refactored to use `ParseOutcome::warnings()` and avoid duplicate warning-handling logic while preserving behavior.
- pnpm commands emitted Node engine warning (`>=24` expected, current `v20.20.0`), but all checks passed.