### PR TITLE
refactor(application): extract DetectionService from AdapterService

### DIFF
--- a/src-tauri/src/application/adapter_service.rs
+++ b/src-tauri/src/application/adapter_service.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use crate::{
     application::{
+        detection::detection_service::DetectionService,
         mcp::{listing_service::McpListingService, mutation_service::McpMutationService},
         skill::{listing_service::SkillListingService, mutation_service::SkillMutationService},
     },
@@ -33,13 +34,8 @@ impl<'a> AdapterService<'a> {
     }
 
     pub fn detect_clients(&self, request: DetectClientsRequest) -> DetectClientsResponse {
-        let clients = self
-            .detector_registry
-            .all()
-            .map(|detector| detector.detect(&request))
-            .collect();
-
-        DetectClientsResponse { clients }
+        let detection_service = DetectionService::new(self.detector_registry);
+        detection_service.detect_clients(&request)
     }
 
     pub fn list_resources(

--- a/src-tauri/src/application/detection/detection_service.rs
+++ b/src-tauri/src/application/detection/detection_service.rs
@@ -1,0 +1,59 @@
+use crate::{
+    contracts::detect::{DetectClientsRequest, DetectClientsResponse},
+    detection::DetectorRegistry,
+};
+
+pub struct DetectionService<'a> {
+    detector_registry: &'a DetectorRegistry,
+}
+
+impl<'a> DetectionService<'a> {
+    pub fn new(detector_registry: &'a DetectorRegistry) -> Self {
+        Self { detector_registry }
+    }
+
+    pub fn detect_clients(&self, request: &DetectClientsRequest) -> DetectClientsResponse {
+        let clients = self
+            .detector_registry
+            .all()
+            .map(|detector| detector.detect(request))
+            .collect();
+
+        DetectClientsResponse { clients }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        contracts::{common::ClientKind, detect::DetectClientsRequest},
+        detection::DetectorRegistry,
+    };
+
+    use super::DetectionService;
+
+    #[test]
+    fn detect_clients_collects_results_from_all_detectors() {
+        let detector_registry = DetectorRegistry::with_default_detectors();
+        let service = DetectionService::new(&detector_registry);
+
+        let response = service.detect_clients(&DetectClientsRequest {
+            include_versions: false,
+        });
+
+        assert_eq!(response.clients.len(), detector_registry.all().count());
+        assert_eq!(
+            response
+                .clients
+                .iter()
+                .map(|detection| detection.client)
+                .collect::<Vec<_>>(),
+            vec![
+                ClientKind::ClaudeCode,
+                ClientKind::CodexCli,
+                ClientKind::Cursor,
+                ClientKind::CodexApp,
+            ]
+        );
+    }
+}

--- a/src-tauri/src/application/detection/mod.rs
+++ b/src-tauri/src/application/detection/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod detection_service;

--- a/src-tauri/src/application/mod.rs
+++ b/src-tauri/src/application/mod.rs
@@ -1,4 +1,5 @@
 mod adapter_service;
+mod detection;
 #[cfg(test)]
 mod critical_paths_suite;
 mod mcp;


### PR DESCRIPTION
## Summary
- add `application/detection/detection_service.rs` as use-case service for client detection
- add `application/detection/mod.rs`
- update `application/mod.rs` to include detection submodule
- update `AdapterService::detect_clients` to delegate to `DetectionService`
- add unit test for `DetectionService` to ensure all detectors are collected in stable order

## Issue
- closes #82
- part of #74
- tracked by #70

## Verification
- `cargo check` (pass)
- `cargo test` (pass; 85 tests)
- `pnpm run lint` (pass)
- `pnpm test` (pass)
- `pnpm outdated` (pass; no outdated packages listed)

## Notes
- Structural refactor only; detection behavior remains unchanged.
- pnpm commands emitted Node engine warning (`>=24` expected, current `v20.20.0`), but all checks passed.