### PR TITLE
refactor(domain): move core enums from contracts to domain

### DIFF
--- a/src-tauri/src/application/mcp/mutation_payload.rs
+++ b/src-tauri/src/application/mcp/mutation_payload.rs
@@ -112,7 +112,7 @@ fn parse_transport_payload(
 
 #[cfg(test)]
 mod tests {
-    use crate::interface::contracts::mutate::MutationAction;
+    use crate::domain::MutationAction;
     use serde_json::json;
 
     use super::{McpTransportPayload, parse_mcp_mutation_payload};

--- a/src-tauri/src/application/skill/listing_service.rs
+++ b/src-tauri/src/application/skill/listing_service.rs
@@ -177,7 +177,7 @@ fn resolve_manifest_candidate(path: &Path) -> Option<SkillManifestCandidate> {
 mod tests {
     use std::fs;
 
-    use crate::interface::contracts::common::ClientKind;
+    use crate::domain::ClientKind;
 
     use super::collect_skills_from_directory;
 

--- a/src-tauri/src/application/skill/mutation_payload.rs
+++ b/src-tauri/src/application/skill/mutation_payload.rs
@@ -125,7 +125,7 @@ fn parse_install_kind(value: &str) -> Result<SkillInstallKind, CommandError> {
 mod tests {
     use serde_json::json;
 
-    use crate::interface::contracts::mutate::MutationAction;
+    use crate::domain::MutationAction;
 
     use super::{SkillInstallKind, parse_skill_mutation_payload};
 

--- a/src-tauri/src/application/skill/path_resolver.rs
+++ b/src-tauri/src/application/skill/path_resolver.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::interface::contracts::common::ClientKind;
+use crate::domain::ClientKind;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SkillDirResolution {
@@ -139,7 +139,7 @@ fn is_readable_dir(path: &Path) -> bool {
 mod tests {
     use std::fs;
 
-    use crate::interface::contracts::common::ClientKind;
+    use crate::domain::ClientKind;
 
     use super::resolve_skill_dir_with_override;
 

--- a/src-tauri/src/domain/client_adapter.rs
+++ b/src-tauri/src/domain/client_adapter.rs
@@ -1,4 +1,6 @@
-use crate::interface::contracts::{common::ResourceKind, list::ResourceRecord, mutate::MutationAction};
+use crate::interface::contracts::list::ResourceRecord;
+
+use super::{MutationAction, ResourceKind};
 
 use super::ClientProfile;
 

--- a/src-tauri/src/domain/client_kind.rs
+++ b/src-tauri/src/domain/client_kind.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientKind {
+    ClaudeCode,
+    CodexCli,
+    Cursor,
+    CodexApp,
+}
+
+impl ClientKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "claude_code",
+            Self::CodexCli => "codex_cli",
+            Self::Cursor => "cursor",
+            Self::CodexApp => "codex_app",
+        }
+    }
+}

--- a/src-tauri/src/domain/client_profile.rs
+++ b/src-tauri/src/domain/client_profile.rs
@@ -1,4 +1,4 @@
-use crate::interface::contracts::common::ClientKind;
+use super::ClientKind;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ClientCapabilities {

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -1,7 +1,13 @@
 mod client_adapter;
+mod client_kind;
 mod client_profile;
+mod mutation_action;
+mod resource_kind;
 
 pub use client_adapter::{AdapterListResult, AdapterMutationResult, ClientAdapter};
+pub use client_kind::ClientKind;
 pub use client_profile::{
     CLAUDE_CODE_PROFILE, CODEX_APP_PROFILE, CODEX_CLI_PROFILE, CURSOR_PROFILE, ClientProfile,
 };
+pub use mutation_action::MutationAction;
+pub use resource_kind::ResourceKind;

--- a/src-tauri/src/domain/mutation_action.rs
+++ b/src-tauri/src/domain/mutation_action.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationAction {
+    Add,
+    Remove,
+    Update,
+}
+
+impl MutationAction {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Add => "add",
+            Self::Remove => "remove",
+            Self::Update => "update",
+        }
+    }
+}

--- a/src-tauri/src/domain/resource_kind.rs
+++ b/src-tauri/src/domain/resource_kind.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceKind {
+    Mcp,
+    Skill,
+}
+
+impl ResourceKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Mcp => "mcp",
+            Self::Skill => "skill",
+        }
+    }
+}

--- a/src-tauri/src/infra/parsers/client_config_parser.rs
+++ b/src-tauri/src/infra/parsers/client_config_parser.rs
@@ -1,4 +1,4 @@
-use crate::interface::contracts::common::ClientKind;
+use crate::domain::ClientKind;
 
 use super::{ParseOutcome, ParsedClientConfig};
 

--- a/src-tauri/src/infra/parsers/fixture_tests.rs
+++ b/src-tauri/src/infra/parsers/fixture_tests.rs
@@ -5,7 +5,7 @@ use std::{
 
 use serde::Deserialize;
 
-use crate::interface::contracts::common::ClientKind;
+use crate::domain::ClientKind;
 
 use super::{ParseOutcome, ParserRegistry};
 

--- a/src-tauri/src/infra/parsers/json_parser.rs
+++ b/src-tauri/src/infra/parsers/json_parser.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-use crate::interface::contracts::common::ClientKind;
+use crate::domain::ClientKind;
 
 use super::{
     ClientConfigParser, ParseError, ParseOutcome, ParseWarning, ParsedClientConfig, ParsedMcpServer,

--- a/src-tauri/src/infra/parsers/registry.rs
+++ b/src-tauri/src/infra/parsers/registry.rs
@@ -1,4 +1,4 @@
-use crate::interface::contracts::common::ClientKind;
+use crate::domain::ClientKind;
 
 use super::{
     ClientConfigParser, ParseError, ParseOutcome, ParsedClientConfig,

--- a/src-tauri/src/infra/parsers/toml_parser.rs
+++ b/src-tauri/src/infra/parsers/toml_parser.rs
@@ -1,4 +1,4 @@
-use crate::interface::contracts::common::ClientKind;
+use crate::domain::ClientKind;
 
 use super::{
     ClientConfigParser, ParseError, ParseOutcome, ParseWarning, ParsedClientConfig, ParsedMcpServer,

--- a/src-tauri/src/infra/parsers/types.rs
+++ b/src-tauri/src/infra/parsers/types.rs
@@ -1,4 +1,4 @@
-use crate::interface::contracts::common::ClientKind;
+use crate::domain::ClientKind;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseWarning {

--- a/src-tauri/src/infra/registry/adapter_registry.rs
+++ b/src-tauri/src/infra/registry/adapter_registry.rs
@@ -1,6 +1,5 @@
 use crate::{
-    interface::contracts::common::ClientKind,
-    domain::ClientAdapter,
+    domain::{ClientAdapter, ClientKind},
     infra::adapters::{ClaudeCodeAdapter, CodexAppAdapter, CodexCliAdapter, CursorAdapter},
 };
 
@@ -36,7 +35,7 @@ impl AdapterRegistry {
 #[cfg(test)]
 mod tests {
     use super::AdapterRegistry;
-    use crate::interface::contracts::common::ClientKind;
+    use crate::domain::ClientKind;
 
     #[test]
     fn default_registry_exposes_all_supported_clients_in_stable_order() {

--- a/src-tauri/src/interface/contracts/common.rs
+++ b/src-tauri/src/interface/contracts/common.rs
@@ -1,40 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ClientKind {
-    ClaudeCode,
-    CodexCli,
-    Cursor,
-    CodexApp,
-}
-
-impl ClientKind {
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::ClaudeCode => "claude_code",
-            Self::CodexCli => "codex_cli",
-            Self::Cursor => "cursor",
-            Self::CodexApp => "codex_app",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ResourceKind {
-    Mcp,
-    Skill,
-}
-
-impl ResourceKind {
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Mcp => "mcp",
-            Self::Skill => "skill",
-        }
-    }
-}
+pub use crate::domain::{ClientKind, ResourceKind};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/src-tauri/src/interface/contracts/detect.rs
+++ b/src-tauri/src/interface/contracts/detect.rs
@@ -52,7 +52,7 @@ impl DetectClientsResponse {
 #[cfg(test)]
 mod tests {
     use super::{ClientDetection, DetectClientsResponse, DetectionEvidence, DetectionStatus};
-    use crate::interface::contracts::common::ClientKind;
+    use crate::domain::ClientKind;
 
     #[test]
     fn detect_response_redacts_notes() {

--- a/src-tauri/src/interface/contracts/list.rs
+++ b/src-tauri/src/interface/contracts/list.rs
@@ -46,7 +46,7 @@ impl ListResourcesResponse {
 #[cfg(test)]
 mod tests {
     use super::ListResourcesResponse;
-    use crate::interface::contracts::common::ResourceKind;
+    use crate::domain::ResourceKind;
 
     #[test]
     fn list_response_redacts_warning() {

--- a/src-tauri/src/interface/contracts/mutate.rs
+++ b/src-tauri/src/interface/contracts/mutate.rs
@@ -2,25 +2,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::common::{ClientKind, ResourceKind};
+pub use crate::domain::MutationAction;
 use crate::infra::security::redaction::redact_sensitive_text;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum MutationAction {
-    Add,
-    Remove,
-    Update,
-}
-
-impl MutationAction {
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Add => "add",
-            Self::Remove => "remove",
-            Self::Update => "update",
-        }
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MutateResourceRequest {

--- a/src-tauri/src/interface/state/app_state.rs
+++ b/src-tauri/src/interface/state/app_state.rs
@@ -88,7 +88,7 @@ impl Default for AppState {
 #[cfg(test)]
 mod tests {
     use super::AppState;
-    use crate::interface::contracts::common::ClientKind;
+    use crate::domain::ClientKind;
 
     #[test]
     fn operation_id_counter_increments_per_command_prefix() {


### PR DESCRIPTION
## Summary
- add `domain::ClientKind`, `domain::ResourceKind`, `domain::MutationAction`
- export moved enums from `domain/mod.rs`
- replace enum definitions in `interface/contracts` with domain re-exports to preserve schema compatibility
- update selected imports to reference `domain` directly (including domain/infra + related tests)

## Compatibility
- enum serde derives and `snake_case` representation are preserved
- request/response contract structures remain unchanged

## Validation
- `cargo check --workspace --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `pnpm run lint`
- `pnpm test`
- `pnpm outdated`

Closes #84