### PR TITLE
refactor(domain): remove remaining domain -> contracts dependency

### DIFF
--- a/src-tauri/src/domain/client_adapter.rs
+++ b/src-tauri/src/domain/client_adapter.rs
@@ -1,6 +1,4 @@
-use crate::interface::contracts::list::ResourceRecord;
-
-use super::{MutationAction, ResourceKind};
+use super::{MutationAction, ResourceKind, ResourceRecord};
 
 use super::ClientProfile;
 

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -3,6 +3,7 @@ mod client_kind;
 mod client_profile;
 mod mutation_action;
 mod resource_kind;
+mod resource_record;
 
 pub use client_adapter::{AdapterListResult, AdapterMutationResult, ClientAdapter};
 pub use client_kind::ClientKind;
@@ -11,3 +12,4 @@ pub use client_profile::{
 };
 pub use mutation_action::MutationAction;
 pub use resource_kind::ResourceKind;
+pub use resource_record::ResourceRecord;

--- a/src-tauri/src/domain/resource_record.rs
+++ b/src-tauri/src/domain/resource_record.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+use super::ClientKind;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceRecord {
+    pub id: String,
+    pub client: ClientKind,
+    pub display_name: String,
+    pub enabled: bool,
+    pub transport_kind: Option<String>,
+    pub transport_command: Option<String>,
+    pub transport_args: Option<Vec<String>>,
+    pub transport_url: Option<String>,
+    pub source_path: Option<String>,
+    pub description: Option<String>,
+    pub install_kind: Option<String>,
+    pub manifest_content: Option<String>,
+}

--- a/src-tauri/src/interface/contracts/list.rs
+++ b/src-tauri/src/interface/contracts/list.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::common::{ClientKind, ResourceKind};
+pub use crate::domain::ResourceRecord;
 use crate::infra::security::redaction::redact_sensitive_text;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -10,22 +11,6 @@ pub struct ListResourcesRequest {
     pub resource_kind: ResourceKind,
     #[serde(default)]
     pub enabled: Option<bool>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ResourceRecord {
-    pub id: String,
-    pub client: ClientKind,
-    pub display_name: String,
-    pub enabled: bool,
-    pub transport_kind: Option<String>,
-    pub transport_command: Option<String>,
-    pub transport_args: Option<Vec<String>>,
-    pub transport_url: Option<String>,
-    pub source_path: Option<String>,
-    pub description: Option<String>,
-    pub install_kind: Option<String>,
-    pub manifest_content: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- move `ResourceRecord` to `domain/resource_record.rs`
- update `domain::ClientAdapter` to use `domain::ResourceRecord` directly
- export `ResourceRecord` from `domain/mod.rs`
- keep `interface/contracts/list.rs` API surface by re-exporting `domain::ResourceRecord`

## Outcome
- removed remaining `domain -> interface/contracts` dependency
- preserved contract behavior and serialization structure

## Validation
- `cargo check --workspace --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `pnpm run lint`
- `pnpm test`
- `pnpm outdated`

Closes #85