### PR TITLE
fix(ci): pass rust fmt/lint/test and keep icon.png as source image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist-ssr
 *.local
 src-tauri/icons/*
 !src-tauri/icons/icon.png
+src-tauri/generated-icons/*
 
 # Editor directories and files
 .vscode/*

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "node": ">=24.0.0"
   },
   "scripts": {
-    "generate:tauri-icons": "pnpm tauri icon src-tauri/icons/icon.png -o src-tauri/icons",
+    "generate:tauri-icons": "pnpm tauri icon src-tauri/icons/icon.png -o src-tauri/generated-icons",
     "typecheck": "tsc --noEmit",
     "fmt:rust": "cargo fmt --manifest-path src-tauri/Cargo.toml -- --check",
-    "test:rust": "cargo test --manifest-path src-tauri/Cargo.toml",
+    "test:rust": "pnpm run generate:tauri-icons && cargo test --manifest-path src-tauri/Cargo.toml",
     "lint:ts": "pnpm run typecheck && biome check .",
-    "lint:rust": "cargo clippy --workspace --all-targets --manifest-path src-tauri/Cargo.toml -- -D warnings",
+    "lint:rust": "pnpm run generate:tauri-icons && cargo clippy --workspace --all-targets --manifest-path src-tauri/Cargo.toml -- -D warnings",
     "lint": "pnpm run lint:ts && pnpm run lint:rust",
     "check": "pnpm run lint && pnpm test",
     "ci:web": "pnpm run lint:ts && pnpm test && pnpm run build",

--- a/src-tauri/src/application/adapter_service.rs
+++ b/src-tauri/src/application/adapter_service.rs
@@ -6,6 +6,7 @@ use crate::{
         mcp::{listing_service::McpListingService, mutation_service::McpMutationService},
         skill::{listing_service::SkillListingService, mutation_service::SkillMutationService},
     },
+    infra::{AdapterRegistry, DetectorRegistry, MutationTestHooks, SafeFileMutator},
     interface::contracts::{
         command::CommandError,
         common::ResourceKind,
@@ -13,7 +14,6 @@ use crate::{
         list::{ListResourcesRequest, ListResourcesResponse},
         mutate::{MutateResourceRequest, MutateResourceResponse},
     },
-    infra::{AdapterRegistry, DetectorRegistry, MutationTestHooks, SafeFileMutator},
 };
 
 pub struct AdapterService<'a> {
@@ -243,14 +243,14 @@ mod tests {
 
     use super::AdapterService;
     use crate::{
+        infra::AdapterRegistry,
+        infra::DetectorRegistry,
         interface::contracts::{
             common::{ClientKind, ResourceKind},
             detect::{DetectClientsRequest, DetectionStatus},
             list::ListResourcesRequest,
             mutate::{MutateResourceRequest, MutationAction},
         },
-        infra::DetectorRegistry,
-        infra::AdapterRegistry,
     };
     use serde_json::json;
 

--- a/src-tauri/src/application/critical_paths_suite.rs
+++ b/src-tauri/src/application/critical_paths_suite.rs
@@ -11,9 +11,9 @@ use super::{
     mcp::mutation_service::McpMutationService, skill::mutation_service::SkillMutationService,
 };
 use crate::{
-    interface::contracts::{common::ClientKind, mutate::MutationAction},
     infra::DetectorRegistry,
     infra::parsers::{ParseOutcome, ParserRegistry},
+    interface::contracts::{common::ClientKind, mutate::MutationAction},
 };
 
 #[derive(Debug, Deserialize)]

--- a/src-tauri/src/application/detection/detection_service.rs
+++ b/src-tauri/src/application/detection/detection_service.rs
@@ -1,6 +1,6 @@
 use crate::{
-    interface::contracts::detect::{DetectClientsRequest, DetectClientsResponse},
     infra::DetectorRegistry,
+    interface::contracts::detect::{DetectClientsRequest, DetectClientsResponse},
 };
 
 pub struct DetectionService<'a> {
@@ -26,8 +26,8 @@ impl<'a> DetectionService<'a> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        interface::contracts::{common::ClientKind, detect::DetectClientsRequest},
         infra::DetectorRegistry,
+        interface::contracts::{common::ClientKind, detect::DetectClientsRequest},
     };
 
     use super::DetectionService;

--- a/src-tauri/src/application/mcp/config_path_resolver.rs
+++ b/src-tauri/src/application/mcp/config_path_resolver.rs
@@ -1,8 +1,8 @@
 use std::{env, path::PathBuf};
 
 use crate::{
-    interface::contracts::{command::CommandError, common::ClientKind, mutate::MutationAction},
     infra::DetectorRegistry,
+    interface::contracts::{command::CommandError, common::ClientKind, mutate::MutationAction},
 };
 
 pub fn resolve_mcp_config_path(

--- a/src-tauri/src/application/mcp/listing_service.rs
+++ b/src-tauri/src/application/mcp/listing_service.rs
@@ -1,12 +1,12 @@
 use std::fs;
 
 use crate::{
+    infra::DetectorRegistry,
+    infra::parsers::{ParseOutcome, ParserRegistry},
     interface::contracts::{
         detect::{ClientDetection, DetectClientsRequest},
         list::{ListResourcesRequest, ResourceRecord},
     },
-    infra::DetectorRegistry,
-    infra::parsers::{ParseOutcome, ParserRegistry},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -153,12 +153,12 @@ where
 mod tests {
     use std::collections::HashMap;
 
+    use crate::infra::parsers::ParserRegistry;
     use crate::interface::contracts::{
         common::{ClientKind, ResourceKind},
         detect::{ClientDetection, DetectionEvidence, DetectionStatus},
         list::ListResourcesRequest,
     };
-    use crate::infra::parsers::ParserRegistry;
 
     use super::collect_from_detections;
 

--- a/src-tauri/src/application/mcp/mutation_service.rs
+++ b/src-tauri/src/application/mcp/mutation_service.rs
@@ -1,9 +1,9 @@
 use std::fs;
 
 use crate::{
-    interface::contracts::{command::CommandError, common::ClientKind, mutate::MutationAction},
     infra::DetectorRegistry,
     infra::SafeFileMutator,
+    interface::contracts::{command::CommandError, common::ClientKind, mutate::MutationAction},
 };
 
 use super::{
@@ -357,8 +357,8 @@ mod tests {
     use serde_json::json;
 
     use crate::{
-        interface::contracts::{common::ClientKind, mutate::MutationAction},
         infra::DetectorRegistry,
+        interface::contracts::{common::ClientKind, mutate::MutationAction},
     };
 
     use super::McpMutationService;

--- a/src-tauri/src/application/mod.rs
+++ b/src-tauri/src/application/mod.rs
@@ -1,7 +1,7 @@
 mod adapter_service;
-mod detection;
 #[cfg(test)]
 mod critical_paths_suite;
+mod detection;
 mod mcp;
 mod skill;
 

--- a/src-tauri/src/application/skill/mutation_path_resolver.rs
+++ b/src-tauri/src/application/skill/mutation_path_resolver.rs
@@ -1,6 +1,8 @@
 use std::{env, path::PathBuf};
 
-use crate::interface::contracts::{command::CommandError, common::ClientKind, mutate::MutationAction};
+use crate::interface::contracts::{
+    command::CommandError, common::ClientKind, mutate::MutationAction,
+};
 
 use super::path_resolver::{preferred_skill_dir, resolve_skill_dir};
 

--- a/src-tauri/src/application/skill/mutation_service.rs
+++ b/src-tauri/src/application/skill/mutation_service.rs
@@ -5,17 +5,15 @@ use std::{
 };
 
 use crate::{
-    interface::contracts::{command::CommandError, common::ClientKind, mutate::MutationAction},
     infra::{MutationTestHooks, SafeFileMutator},
+    interface::contracts::{command::CommandError, common::ClientKind, mutate::MutationAction},
 };
 
 use super::{
     github_repository::read_github_skill_manifest,
     metadata_parser::parse_skill_metadata,
     mutation_path_resolver::resolve_skill_root_path,
-    mutation_payload::{
-        SkillInstallKind, SkillMutationPayload, parse_skill_mutation_payload,
-    },
+    mutation_payload::{SkillInstallKind, SkillMutationPayload, parse_skill_mutation_payload},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src-tauri/src/infra/adapters/claude_code.rs
+++ b/src-tauri/src/infra/adapters/claude_code.rs
@@ -1,8 +1,8 @@
 use crate::{
-    interface::contracts::{common::ResourceKind, mutate::MutationAction},
     domain::{
         AdapterListResult, AdapterMutationResult, CLAUDE_CODE_PROFILE, ClientAdapter, ClientProfile,
     },
+    interface::contracts::{common::ResourceKind, mutate::MutationAction},
 };
 
 use super::placeholder::{list_placeholder, mutate_placeholder};

--- a/src-tauri/src/infra/adapters/codex_app.rs
+++ b/src-tauri/src/infra/adapters/codex_app.rs
@@ -1,8 +1,8 @@
 use crate::{
-    interface::contracts::{common::ResourceKind, mutate::MutationAction},
     domain::{
         AdapterListResult, AdapterMutationResult, CODEX_APP_PROFILE, ClientAdapter, ClientProfile,
     },
+    interface::contracts::{common::ResourceKind, mutate::MutationAction},
 };
 
 use super::placeholder::{list_placeholder, mutate_placeholder};

--- a/src-tauri/src/infra/adapters/codex_cli.rs
+++ b/src-tauri/src/infra/adapters/codex_cli.rs
@@ -1,8 +1,8 @@
 use crate::{
-    interface::contracts::{common::ResourceKind, mutate::MutationAction},
     domain::{
         AdapterListResult, AdapterMutationResult, CODEX_CLI_PROFILE, ClientAdapter, ClientProfile,
     },
+    interface::contracts::{common::ResourceKind, mutate::MutationAction},
 };
 
 use super::placeholder::{list_placeholder, mutate_placeholder};

--- a/src-tauri/src/infra/adapters/cursor.rs
+++ b/src-tauri/src/infra/adapters/cursor.rs
@@ -1,8 +1,8 @@
 use crate::{
-    interface::contracts::{common::ResourceKind, mutate::MutationAction},
     domain::{
         AdapterListResult, AdapterMutationResult, CURSOR_PROFILE, ClientAdapter, ClientProfile,
     },
+    interface::contracts::{common::ResourceKind, mutate::MutationAction},
 };
 
 use super::placeholder::{list_placeholder, mutate_placeholder};

--- a/src-tauri/src/infra/adapters/placeholder.rs
+++ b/src-tauri/src/infra/adapters/placeholder.rs
@@ -1,6 +1,6 @@
 use crate::{
-    interface::contracts::{common::ResourceKind, mutate::MutationAction},
     domain::{AdapterListResult, AdapterMutationResult, ClientProfile},
+    interface::contracts::{common::ResourceKind, mutate::MutationAction},
 };
 
 pub fn list_placeholder(

--- a/src-tauri/src/infra/mod.rs
+++ b/src-tauri/src/infra/mod.rs
@@ -6,5 +6,5 @@ pub mod registry;
 pub mod security;
 
 pub use detection::DetectorRegistry;
-pub use registry::AdapterRegistry;
 pub use mutation::{MutationTestHooks, SafeFileMutator};
+pub use registry::AdapterRegistry;

--- a/src-tauri/src/interface/state/app_state.rs
+++ b/src-tauri/src/interface/state/app_state.rs
@@ -3,9 +3,9 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
 };
 
-use crate::interface::contracts::common::{LifecyclePhase, LifecycleSnapshot};
-use crate::infra::DetectorRegistry;
 use crate::infra::AdapterRegistry;
+use crate::infra::DetectorRegistry;
+use crate::interface::contracts::common::{LifecyclePhase, LifecycleSnapshot};
 
 use super::clock::now_epoch_ms;
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,6 +22,13 @@
     }
   },
   "bundle": {
-    "active": true
+    "active": true,
+    "icon": [
+      "generated-icons/32x32.png",
+      "generated-icons/128x128.png",
+      "generated-icons/128x128@2x.png",
+      "generated-icons/icon.icns",
+      "generated-icons/icon.ico"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- fix `cargo fmt --check` drift by applying rustfmt to affected Rust modules
- stop icon generation from writing into `src-tauri/icons` (where `icon.png` is the base source)
- generate icons into `src-tauri/generated-icons` instead
- configure Tauri bundle icon paths to `generated-icons/*`
- ensure rust lint/test scripts generate icons before clippy/test so CI rust job can compile `generate_context!` reliably
- ignore generated icon output directory in git

## Why
- CI `Run fmt + lint + test (rust)` was failing due formatting drift
- `src-tauri/icons/icon.png` was being overwritten by auto-generation and should remain the base image

## Validation
- `pnpm run ci:rust`
- `pnpm run ci:web`
- `pnpm run lint`
- `pnpm test`
- `pnpm outdated`