### PR TITLE
feat: add client capability matrix for resource scopes

### DIFF
--- a/src-tauri/src/application/capability/client_capability_service.rs
+++ b/src-tauri/src/application/capability/client_capability_service.rs
@@ -1,0 +1,112 @@
+use crate::domain::{
+    ClientKind, ClientProfile, ResourceKind, ResourceSourceScope, profile_for_client,
+};
+
+pub struct ClientCapabilityService;
+
+impl ClientCapabilityService {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn profile(&self, client: ClientKind) -> &'static ClientProfile {
+        profile_for_client(client)
+    }
+
+    pub fn source_scopes_for(
+        &self,
+        client: ClientKind,
+        resource_kind: ResourceKind,
+    ) -> &'static [ResourceSourceScope] {
+        self.profile(client)
+            .capabilities
+            .source_scopes_for(resource_kind)
+    }
+
+    pub fn destination_scopes_for(
+        &self,
+        client: ClientKind,
+        resource_kind: ResourceKind,
+    ) -> &'static [ResourceSourceScope] {
+        self.profile(client)
+            .capabilities
+            .destination_scopes_for(resource_kind)
+    }
+
+    pub fn supports_source(
+        &self,
+        client: ClientKind,
+        resource_kind: ResourceKind,
+        scope: ResourceSourceScope,
+    ) -> bool {
+        self.profile(client)
+            .capabilities
+            .supports_source(resource_kind, scope)
+    }
+
+    pub fn supports_destination(
+        &self,
+        client: ClientKind,
+        resource_kind: ResourceKind,
+        scope: ResourceSourceScope,
+    ) -> bool {
+        self.profile(client)
+            .capabilities
+            .supports_destination(resource_kind, scope)
+    }
+}
+
+impl Default for ClientCapabilityService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ClientCapabilityService;
+    use crate::domain::{ClientKind, ResourceKind, ResourceSourceScope};
+
+    #[test]
+    fn service_exposes_distinct_mcp_scope_support_by_client() {
+        let service = ClientCapabilityService::new();
+
+        assert!(service.supports_source(
+            ClientKind::ClaudeCode,
+            ResourceKind::Mcp,
+            ResourceSourceScope::ProjectPrivate
+        ));
+        assert!(service.supports_source(
+            ClientKind::Cursor,
+            ResourceKind::Mcp,
+            ResourceSourceScope::ProjectShared
+        ));
+        assert!(!service.supports_source(
+            ClientKind::Codex,
+            ResourceKind::Mcp,
+            ResourceSourceScope::ProjectShared
+        ));
+    }
+
+    #[test]
+    fn service_exposes_user_only_skill_support_for_now() {
+        let service = ClientCapabilityService::new();
+
+        for client in [
+            ClientKind::ClaudeCode,
+            ClientKind::Codex,
+            ClientKind::Cursor,
+        ] {
+            assert!(service.supports_destination(
+                client,
+                ResourceKind::Skill,
+                ResourceSourceScope::User
+            ));
+            assert!(!service.supports_destination(
+                client,
+                ResourceKind::Skill,
+                ResourceSourceScope::ProjectShared
+            ));
+        }
+    }
+}

--- a/src-tauri/src/application/capability/mod.rs
+++ b/src-tauri/src/application/capability/mod.rs
@@ -1,0 +1,1 @@
+pub mod client_capability_service;

--- a/src-tauri/src/application/mod.rs
+++ b/src-tauri/src/application/mod.rs
@@ -1,4 +1,5 @@
 mod adapter_service;
+mod capability;
 #[cfg(test)]
 mod critical_paths_suite;
 mod detection;
@@ -6,4 +7,5 @@ mod mcp;
 mod skill;
 
 pub use adapter_service::AdapterService;
+pub use capability::client_capability_service::ClientCapabilityService;
 pub use skill::repository_discovery_service::SkillRepositoryDiscoveryService;

--- a/src-tauri/src/domain/client_profile.rs
+++ b/src-tauri/src/domain/client_profile.rs
@@ -1,9 +1,77 @@
-use super::ClientKind;
+use super::{ClientKind, ResourceKind, ResourceSourceScope};
+
+const EMPTY_SCOPES: &[ResourceSourceScope] = &[];
+const USER_ONLY_SCOPES: &[ResourceSourceScope] = &[ResourceSourceScope::User];
+const CLAUDE_MCP_SCOPES: &[ResourceSourceScope] = &[
+    ResourceSourceScope::User,
+    ResourceSourceScope::ProjectShared,
+    ResourceSourceScope::ProjectPrivate,
+];
+const CURSOR_MCP_SCOPES: &[ResourceSourceScope] = &[
+    ResourceSourceScope::User,
+    ResourceSourceScope::ProjectShared,
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResourceScopeCapabilities {
+    pub source_scopes: &'static [ResourceSourceScope],
+    pub destination_scopes: &'static [ResourceSourceScope],
+}
+
+impl ResourceScopeCapabilities {
+    pub fn supports_source(self, scope: ResourceSourceScope) -> bool {
+        self.source_scopes.contains(&scope)
+    }
+
+    pub fn supports_destination(self, scope: ResourceSourceScope) -> bool {
+        self.destination_scopes.contains(&scope)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ClientCapabilities {
     pub supports_mcp: bool,
     pub supports_skills: bool,
+    pub mcp: Option<ResourceScopeCapabilities>,
+    pub skills: Option<ResourceScopeCapabilities>,
+}
+
+impl ClientCapabilities {
+    pub fn support_for(self, resource_kind: ResourceKind) -> Option<ResourceScopeCapabilities> {
+        match resource_kind {
+            ResourceKind::Mcp => self.mcp,
+            ResourceKind::Skill => self.skills,
+        }
+    }
+
+    pub fn source_scopes_for(self, resource_kind: ResourceKind) -> &'static [ResourceSourceScope] {
+        self.support_for(resource_kind)
+            .map(|support| support.source_scopes)
+            .unwrap_or(EMPTY_SCOPES)
+    }
+
+    pub fn destination_scopes_for(
+        self,
+        resource_kind: ResourceKind,
+    ) -> &'static [ResourceSourceScope] {
+        self.support_for(resource_kind)
+            .map(|support| support.destination_scopes)
+            .unwrap_or(EMPTY_SCOPES)
+    }
+
+    pub fn supports_source(self, resource_kind: ResourceKind, scope: ResourceSourceScope) -> bool {
+        self.support_for(resource_kind)
+            .is_some_and(|support| support.supports_source(scope))
+    }
+
+    pub fn supports_destination(
+        self,
+        resource_kind: ResourceKind,
+        scope: ResourceSourceScope,
+    ) -> bool {
+        self.support_for(resource_kind)
+            .is_some_and(|support| support.supports_destination(scope))
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -21,6 +89,14 @@ pub const CLAUDE_CODE_PROFILE: ClientProfile = ClientProfile {
     capabilities: ClientCapabilities {
         supports_mcp: true,
         supports_skills: true,
+        mcp: Some(ResourceScopeCapabilities {
+            source_scopes: CLAUDE_MCP_SCOPES,
+            destination_scopes: CLAUDE_MCP_SCOPES,
+        }),
+        skills: Some(ResourceScopeCapabilities {
+            source_scopes: USER_ONLY_SCOPES,
+            destination_scopes: USER_ONLY_SCOPES,
+        }),
     },
 };
 
@@ -31,6 +107,14 @@ pub const CODEX_PROFILE: ClientProfile = ClientProfile {
     capabilities: ClientCapabilities {
         supports_mcp: true,
         supports_skills: true,
+        mcp: Some(ResourceScopeCapabilities {
+            source_scopes: USER_ONLY_SCOPES,
+            destination_scopes: USER_ONLY_SCOPES,
+        }),
+        skills: Some(ResourceScopeCapabilities {
+            source_scopes: USER_ONLY_SCOPES,
+            destination_scopes: USER_ONLY_SCOPES,
+        }),
     },
 };
 
@@ -41,5 +125,93 @@ pub const CURSOR_PROFILE: ClientProfile = ClientProfile {
     capabilities: ClientCapabilities {
         supports_mcp: true,
         supports_skills: true,
+        mcp: Some(ResourceScopeCapabilities {
+            source_scopes: CURSOR_MCP_SCOPES,
+            destination_scopes: CURSOR_MCP_SCOPES,
+        }),
+        skills: Some(ResourceScopeCapabilities {
+            source_scopes: USER_ONLY_SCOPES,
+            destination_scopes: USER_ONLY_SCOPES,
+        }),
     },
 };
+
+pub fn profile_for_client(client: ClientKind) -> &'static ClientProfile {
+    match client {
+        ClientKind::ClaudeCode => &CLAUDE_CODE_PROFILE,
+        ClientKind::Codex => &CODEX_PROFILE,
+        ClientKind::Cursor => &CURSOR_PROFILE,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClientKind, profile_for_client};
+    use crate::domain::{ResourceKind, ResourceSourceScope};
+
+    #[test]
+    fn claude_mcp_supports_user_and_project_scopes() {
+        let capabilities = profile_for_client(ClientKind::ClaudeCode).capabilities;
+
+        assert!(capabilities.supports_source(ResourceKind::Mcp, ResourceSourceScope::User));
+        assert!(
+            capabilities.supports_source(ResourceKind::Mcp, ResourceSourceScope::ProjectShared)
+        );
+        assert!(
+            capabilities.supports_source(ResourceKind::Mcp, ResourceSourceScope::ProjectPrivate)
+        );
+        assert!(
+            capabilities
+                .supports_destination(ResourceKind::Mcp, ResourceSourceScope::ProjectPrivate)
+        );
+    }
+
+    #[test]
+    fn cursor_mcp_is_project_aware_but_not_project_private() {
+        let capabilities = profile_for_client(ClientKind::Cursor).capabilities;
+
+        assert!(
+            capabilities.supports_source(ResourceKind::Mcp, ResourceSourceScope::ProjectShared)
+        );
+        assert!(
+            !capabilities.supports_source(ResourceKind::Mcp, ResourceSourceScope::ProjectPrivate)
+        );
+        assert!(
+            !capabilities
+                .supports_destination(ResourceKind::Mcp, ResourceSourceScope::ProjectPrivate)
+        );
+    }
+
+    #[test]
+    fn codex_mcp_remains_user_only() {
+        let capabilities = profile_for_client(ClientKind::Codex).capabilities;
+
+        assert_eq!(
+            capabilities.source_scopes_for(ResourceKind::Mcp),
+            &[ResourceSourceScope::User]
+        );
+        assert_eq!(
+            capabilities.destination_scopes_for(ResourceKind::Mcp),
+            &[ResourceSourceScope::User]
+        );
+    }
+
+    #[test]
+    fn skill_support_remains_user_only_for_all_clients() {
+        for client in [
+            ClientKind::ClaudeCode,
+            ClientKind::Codex,
+            ClientKind::Cursor,
+        ] {
+            let capabilities = profile_for_client(client).capabilities;
+            assert_eq!(
+                capabilities.source_scopes_for(ResourceKind::Skill),
+                &[ResourceSourceScope::User]
+            );
+            assert_eq!(
+                capabilities.destination_scopes_for(ResourceKind::Skill),
+                &[ResourceSourceScope::User]
+            );
+        }
+    }
+}

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -8,7 +8,10 @@ mod resource_source;
 
 pub use client_adapter::{AdapterListResult, AdapterMutationResult, ClientAdapter};
 pub use client_kind::ClientKind;
-pub use client_profile::{CLAUDE_CODE_PROFILE, CODEX_PROFILE, CURSOR_PROFILE, ClientProfile};
+pub use client_profile::{
+    CLAUDE_CODE_PROFILE, CODEX_PROFILE, CURSOR_PROFILE, ClientCapabilities, ClientProfile,
+    ResourceScopeCapabilities, profile_for_client,
+};
 pub use mutation_action::MutationAction;
 pub use resource_kind::ResourceKind;
 pub use resource_record::ResourceRecord;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,12 @@ mod domain;
 mod infra;
 mod interface;
 
+pub use application::ClientCapabilityService;
+pub use domain::{
+    ClientCapabilities, ClientKind, ClientProfile, ResourceKind, ResourceScopeCapabilities,
+    ResourceSourceScope, profile_for_client,
+};
+
 use interface::{
     commands::{detect_clients, discover_skill_repository, list_resources, mutate_resource},
     state::AppState,


### PR DESCRIPTION
## Summary
- add a client capability matrix for source and destination scope support
- model Claude, Cursor, and Codex MCP support explicitly instead of assuming identical scopes
- expose capability queries through an application-layer service for follow-up issues

## Details
- extended `ClientCapabilities` with per-resource source and destination scope support
- added `ResourceScopeCapabilities` and `profile_for_client` helpers in the domain layer
- encoded current support as:
  - Claude MCP: `user`, `project_shared`, `project_private`
  - Cursor MCP: `user`, `project_shared`
  - Codex MCP: `user` only
  - Skills: `user` only for now across clients
- added `ClientCapabilityService` so later phases can query supported sources/destinations from application code
- added unit tests covering MCP scope differences and current skill scope behavior

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --workspace --all-targets --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `pnpm run ci:rust`
- `pnpm run lint`
- `pnpm test`

## Related
- Closes #112
- Part of #106