### PR TITLE
feat: normalize and validate project context roots

### DIFF
--- a/src-tauri/src/application/adapter_service.rs
+++ b/src-tauri/src/application/adapter_service.rs
@@ -4,6 +4,7 @@ use crate::{
     application::{
         detection::detection_service::DetectionService,
         mcp::{listing_service::McpListingService, mutation_service::McpMutationService},
+        project_context_resolver::ProjectContextResolver,
         skill::{listing_service::SkillListingService, mutation_service::SkillMutationService},
     },
     infra::{AdapterRegistry, DetectorRegistry, MutationTestHooks, SafeFileMutator},
@@ -41,6 +42,13 @@ impl<'a> AdapterService<'a> {
         &self,
         request: ListResourcesRequest,
     ) -> Result<ListResourcesResponse, CommandError> {
+        let project_root =
+            ProjectContextResolver::new().resolve(request.project_root.as_deref())?;
+        let request = ListResourcesRequest {
+            project_root: project_root.clone(),
+            ..request
+        };
+
         if matches!(request.resource_kind, ResourceKind::Mcp) {
             let mcp_listing_service = McpListingService::new(self.detector_registry);
             let result = mcp_listing_service.list(&request);
@@ -87,6 +95,8 @@ impl<'a> AdapterService<'a> {
         &self,
         request: &MutateResourceRequest,
     ) -> Result<MutateResourceResponse, CommandError> {
+        let _project_root =
+            ProjectContextResolver::new().resolve(request.project_root.as_deref())?;
         let target_id = request.target_id.trim();
 
         if target_id.is_empty() {
@@ -291,21 +301,37 @@ mod tests {
         let adapter_registry = AdapterRegistry::with_default_adapters();
         let detector_registry = DetectorRegistry::with_default_detectors();
         let service = AdapterService::new(&adapter_registry, &detector_registry);
+        let temp_dir = std::env::temp_dir().join(format!(
+            "ai-manager-list-project-context-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&temp_dir);
+        let _ = fs::create_dir_all(temp_dir.join("nested"));
+        let request_root = temp_dir.join("nested").join("..");
 
         let response = service
             .list_resources(ListResourcesRequest {
                 client: Some(ClientKind::Cursor),
                 resource_kind: ResourceKind::Skill,
                 enabled: None,
-                project_root: Some("/tmp/project".to_string()),
+                project_root: Some(request_root.display().to_string()),
                 view_mode: ResourceViewMode::AllSources,
                 scope_filter: None,
             })
             .expect("skill list should resolve through skill listing service");
+        let expected_root = temp_dir
+            .canonicalize()
+            .expect("project root should canonicalize")
+            .display()
+            .to_string();
+        let _ = fs::remove_dir_all(&temp_dir);
 
         assert_eq!(response.client, Some(ClientKind::Cursor));
         assert!(matches!(response.resource_kind, ResourceKind::Skill));
-        assert_eq!(response.project_root.as_deref(), Some("/tmp/project"));
+        assert_eq!(
+            response.project_root.as_deref(),
+            Some(expected_root.as_str())
+        );
         assert!(matches!(response.view_mode, ResourceViewMode::AllSources));
     }
 
@@ -348,6 +374,55 @@ mod tests {
             .expect_err("blank target_id should fail validation");
 
         assert!(error.message.contains("target_id"));
+    }
+
+    #[test]
+    fn list_resources_rejects_missing_project_root() {
+        let adapter_registry = AdapterRegistry::with_default_adapters();
+        let detector_registry = DetectorRegistry::with_default_detectors();
+        let service = AdapterService::new(&adapter_registry, &detector_registry);
+        let missing_root = std::env::temp_dir().join(format!(
+            "ai-manager-missing-project-root-{}",
+            std::process::id()
+        ));
+
+        let error = service
+            .list_resources(ListResourcesRequest {
+                client: Some(ClientKind::Cursor),
+                resource_kind: ResourceKind::Skill,
+                enabled: None,
+                project_root: Some(missing_root.display().to_string()),
+                view_mode: ResourceViewMode::Effective,
+                scope_filter: None,
+            })
+            .expect_err("missing project root should fail validation");
+
+        assert!(error.message.contains("existing directory"));
+    }
+
+    #[test]
+    fn mutate_resource_rejects_missing_project_root() {
+        let adapter_registry = AdapterRegistry::with_default_adapters();
+        let detector_registry = DetectorRegistry::with_default_detectors();
+        let service = AdapterService::new(&adapter_registry, &detector_registry);
+        let missing_root = std::env::temp_dir().join(format!(
+            "ai-manager-missing-project-root-mutate-{}",
+            std::process::id()
+        ));
+
+        let error = service
+            .mutate_resource(&MutateResourceRequest {
+                client: ClientKind::ClaudeCode,
+                resource_kind: ResourceKind::Mcp,
+                action: MutationAction::Add,
+                target_id: "filesystem".to_string(),
+                project_root: Some(missing_root.display().to_string()),
+                target_source_id: None,
+                payload: None,
+            })
+            .expect_err("missing project root should fail validation");
+
+        assert!(error.message.contains("existing directory"));
     }
 
     #[test]

--- a/src-tauri/src/application/mod.rs
+++ b/src-tauri/src/application/mod.rs
@@ -4,6 +4,7 @@ mod capability;
 mod critical_paths_suite;
 mod detection;
 mod mcp;
+mod project_context_resolver;
 mod skill;
 
 pub use adapter_service::AdapterService;

--- a/src-tauri/src/application/project_context_resolver.rs
+++ b/src-tauri/src/application/project_context_resolver.rs
@@ -1,0 +1,175 @@
+use std::{env, fs, path::PathBuf};
+
+use crate::interface::contracts::command::CommandError;
+
+#[derive(Debug, Clone, Default)]
+pub struct ProjectContextResolver {
+    home_dir: Option<PathBuf>,
+}
+
+impl ProjectContextResolver {
+    pub fn new() -> Self {
+        Self {
+            home_dir: env::var_os("HOME").map(PathBuf::from),
+        }
+    }
+
+    pub fn resolve(&self, project_root: Option<&str>) -> Result<Option<String>, CommandError> {
+        let Some(project_root) = project_root.map(str::trim) else {
+            return Ok(None);
+        };
+
+        if project_root.is_empty() {
+            return Ok(None);
+        }
+
+        let expanded = self.expand_user_path(project_root)?;
+
+        if !expanded.exists() {
+            return Err(CommandError::validation(
+                "project_root must reference an existing directory.",
+            ));
+        }
+
+        if !expanded.is_dir() {
+            return Err(CommandError::validation(
+                "project_root must reference a directory.",
+            ));
+        }
+
+        let canonical = fs::canonicalize(&expanded)
+            .map_err(|_| CommandError::validation("project_root could not be canonicalized."))?;
+
+        Ok(Some(canonical.to_string_lossy().into_owned()))
+    }
+
+    fn expand_user_path(&self, value: &str) -> Result<PathBuf, CommandError> {
+        if value == "~" {
+            return self.home_dir.clone().ok_or_else(|| {
+                CommandError::validation("project_root uses '~' but HOME is not available.")
+            });
+        }
+
+        if let Some(relative_path) = value.strip_prefix("~/") {
+            let Some(home_dir) = &self.home_dir else {
+                return Err(CommandError::validation(
+                    "project_root uses '~' but HOME is not available.",
+                ));
+            };
+
+            return Ok(home_dir.join(relative_path));
+        }
+
+        Ok(PathBuf::from(value))
+    }
+
+    #[cfg(test)]
+    fn with_home_dir(home_dir: Option<PathBuf>) -> Self {
+        Self { home_dir }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::ProjectContextResolver;
+
+    #[test]
+    fn resolve_returns_none_when_project_root_is_missing_or_blank() {
+        let resolver = ProjectContextResolver::with_home_dir(None);
+
+        assert_eq!(
+            resolver.resolve(None).expect("missing root should pass"),
+            None
+        );
+        assert_eq!(
+            resolver
+                .resolve(Some("   "))
+                .expect("blank root should pass"),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_expands_home_relative_paths() {
+        let home_dir = test_root("home");
+        let project_root = home_dir.join("workspace");
+        fs::create_dir_all(&project_root).expect("home project root should exist");
+        let expected_root = project_root
+            .canonicalize()
+            .expect("canonical path")
+            .display()
+            .to_string();
+
+        let resolver = ProjectContextResolver::with_home_dir(Some(home_dir.clone()));
+        let resolved = resolver
+            .resolve(Some("~/workspace"))
+            .expect("home relative path should resolve");
+
+        let _ = fs::remove_dir_all(&home_dir);
+
+        assert_eq!(resolved, Some(expected_root));
+    }
+
+    #[test]
+    fn resolve_rejects_missing_directories() {
+        let resolver = ProjectContextResolver::with_home_dir(None);
+        let missing_root = test_root("missing");
+
+        let error = resolver
+            .resolve(Some(&missing_root.display().to_string()))
+            .expect_err("missing project root should fail");
+
+        assert!(error.message.contains("existing directory"));
+    }
+
+    #[test]
+    fn resolve_rejects_files() {
+        let root = test_root("file");
+        fs::create_dir_all(&root).expect("root should be writable");
+        let file_path = root.join("project.txt");
+        fs::write(&file_path, "not a directory").expect("file should be writable");
+
+        let resolver = ProjectContextResolver::with_home_dir(None);
+        let error = resolver
+            .resolve(Some(&file_path.display().to_string()))
+            .expect_err("file path should fail");
+
+        let _ = fs::remove_dir_all(&root);
+
+        assert!(error.message.contains("reference a directory"));
+    }
+
+    #[test]
+    fn resolve_canonicalizes_existing_directories() {
+        let root = test_root("canonical");
+        let project_root = root.join("repo");
+        fs::create_dir_all(&project_root).expect("project root should be writable");
+        fs::create_dir_all(root.join("nested")).expect("nested path should exist");
+        let expected_root = project_root
+            .canonicalize()
+            .expect("canonical path")
+            .display()
+            .to_string();
+
+        let request_root = root.join("nested").join("..").join("repo");
+        let resolver = ProjectContextResolver::with_home_dir(None);
+        let resolved = resolver
+            .resolve(Some(&request_root.display().to_string()))
+            .expect("existing project root should resolve");
+
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(resolved, Some(expected_root));
+    }
+
+    fn test_root(name: &str) -> std::path::PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "ai-manager-project-context-{name}-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        root
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `ProjectContextResolver` to normalize `project_root`, expand `~`, and validate that selected roots exist as directories
- normalize project roots at the `AdapterService` boundary so list responses return canonical paths and mutations reject invalid project context early
- cover canonicalization and validation behavior with resolver and adapter-level tests

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `pnpm run ci:rust`
- `pnpm run lint`
- `pnpm test`
- `pnpm outdated` (reported newer `@biomejs/biome` 2.4.6 and `@tauri-apps/cli` 2.10.1)

Closes #113