### PR TITLE
chore: update source-aware specs and fixtures

### DIFF
--- a/docs/spec/normalized-domain-model.md
+++ b/docs/spec/normalized-domain-model.md
@@ -1,26 +1,32 @@
 # Normalized Domain Model v1
 
-This document defines the normalized model required by issue `#11`.
+This document defines the source-aware normalized model required by issues `#106` and `#114`.
 
 ## Design Goals
 
 - Represent all supported client formats without lossy conversion.
 - Keep model boundaries clear across `Client`, `MCP`, and `Skill`.
 - Expose explicit extension points for future attributes.
-- Keep source traceability (`origin/path/line/column/warnings`) for every normalized entity.
+- Keep source traceability for every normalized entity.
+- Separate source-aware record identity from logical resource identity.
+- Make staged source/destination support explicit without pretending all clients share the same native scope model.
 
 ## Entity Boundaries
 
 1. `Client`
 - Runtime detection status and capabilities.
 - No MCP/Skill payload fields embedded directly.
+- `capabilities.scopeSupport` records current vs target source/destination scopes for each resource kind.
 
 2. `MCP`
 - Runtime configuration details for tool servers.
 - Transport and environment fields are isolated in dedicated sub-objects.
+- `id` is source-aware; `logicalId` stays stable across scopes.
+- `source` carries scope, source container, effective state, and shadowing metadata.
 
 3. `Skill`
 - Installation target and metadata independent from MCP transport details.
+- Uses the same source-aware identity and source metadata pattern as MCP records.
 
 ## Lossless Mapping Strategy
 
@@ -28,11 +34,19 @@ This document defines the normalized model required by issue `#11`.
   - `source`: where the normalized item came from
   - `raw`: provider/client-specific original fields
 - `raw` ensures that unsupported vendor fields can be retained without changing the normalized schema.
+- Source-aware records keep both `id` and `logicalId` so the same named resource can coexist across multiple sources.
 
 ## Extension Points
 
 - Every entity includes `extensions: {}` for forward-compatible attributes.
 - Extensions are intentionally unconstrained to avoid schema churn when new clients are added.
+
+## Staged Support
+
+- `current*Scopes` describe what the repo can list/mutate today.
+- `target*Scopes` describe the intended source-aware model for staged rollout.
+- Codex remains user-only unless upstream project-local MCP support becomes official.
+- Project-scoped skill support stays out of scope until taxonomy is resolved in `#110`.
 
 ## Files
 

--- a/docs/spec/normalized-domain-model.v1.json
+++ b/docs/spec/normalized-domain-model.v1.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../schemas/normalized-domain-model.schema.json",
-  "version": "1.0.0",
-  "updatedAt": "2026-03-03",
+  "version": "1.1.0",
+  "updatedAt": "2026-03-08",
   "entities": {
     "clients": [
       {
@@ -12,7 +12,41 @@
         "capabilities": {
           "supportsMcp": true,
           "supportsSkills": true,
-          "supportsEnableDisable": true
+          "supportsEnableDisable": true,
+          "scopeSupport": {
+            "mcp": {
+              "currentSourceScopes": [
+                "user"
+              ],
+              "targetSourceScopes": [
+                "user",
+                "project_shared",
+                "project_private"
+              ],
+              "currentDestinationScopes": [
+                "user"
+              ],
+              "targetDestinationScopes": [
+                "user",
+                "project_shared",
+                "project_private"
+              ]
+            },
+            "skills": {
+              "currentSourceScopes": [
+                "user"
+              ],
+              "targetSourceScopes": [
+                "user"
+              ],
+              "currentDestinationScopes": [
+                "user"
+              ],
+              "targetDestinationScopes": [
+                "user"
+              ]
+            }
+          }
         },
         "source": {
           "origin": "detector",
@@ -27,6 +61,60 @@
         }
       },
       {
+        "id": "client:codex:default",
+        "clientType": "codex",
+        "displayName": "Codex",
+        "status": "partial",
+        "capabilities": {
+          "supportsMcp": true,
+          "supportsSkills": true,
+          "supportsEnableDisable": false,
+          "scopeSupport": {
+            "mcp": {
+              "currentSourceScopes": [
+                "user"
+              ],
+              "targetSourceScopes": [
+                "user"
+              ],
+              "currentDestinationScopes": [
+                "user"
+              ],
+              "targetDestinationScopes": [
+                "user"
+              ]
+            },
+            "skills": {
+              "currentSourceScopes": [
+                "user"
+              ],
+              "targetSourceScopes": [
+                "user"
+              ],
+              "currentDestinationScopes": [
+                "user"
+              ],
+              "targetDestinationScopes": [
+                "user"
+              ]
+            }
+          }
+        },
+        "source": {
+          "origin": "detector",
+          "path": "~/.codex/config.toml",
+          "warnings": [
+            "app_install_missing"
+          ]
+        },
+        "raw": {
+          "appDataRoot": "~/.codex"
+        },
+        "extensions": {
+          "futureClientMetadata": {}
+        }
+      },
+      {
         "id": "client:cursor:default",
         "clientType": "cursor",
         "displayName": "Cursor",
@@ -34,7 +122,39 @@
         "capabilities": {
           "supportsMcp": true,
           "supportsSkills": true,
-          "supportsEnableDisable": false
+          "supportsEnableDisable": false,
+          "scopeSupport": {
+            "mcp": {
+              "currentSourceScopes": [
+                "user"
+              ],
+              "targetSourceScopes": [
+                "user",
+                "project_shared"
+              ],
+              "currentDestinationScopes": [
+                "user"
+              ],
+              "targetDestinationScopes": [
+                "user",
+                "project_shared"
+              ]
+            },
+            "skills": {
+              "currentSourceScopes": [
+                "user"
+              ],
+              "targetSourceScopes": [
+                "user"
+              ],
+              "currentDestinationScopes": [
+                "user"
+              ],
+              "targetDestinationScopes": [
+                "user"
+              ]
+            }
+          }
         },
         "source": {
           "origin": "detector",
@@ -53,7 +173,8 @@
     ],
     "mcps": [
       {
-        "id": "mcp:claude_code:filesystem",
+        "id": "mcp:claude_code:user:filesystem",
+        "logicalId": "mcp:claude_code:filesystem",
         "clientId": "client:claude_code:default",
         "name": "filesystem",
         "enabled": true,
@@ -75,7 +196,13 @@
         ],
         "source": {
           "origin": "mcp_config",
-          "path": "~/.claude.json",
+          "path": "~/.claude.json#/mcpServers/filesystem",
+          "containerPath": "~/.claude.json",
+          "sourceId": "mcp::claude_code::user::~/.claude.json#/mcpServers",
+          "scope": "user",
+          "label": "Personal config",
+          "isEffective": false,
+          "shadowedBy": "mcp:claude_code:project_shared:filesystem",
           "line": 18,
           "column": 9,
           "warnings": []
@@ -88,11 +215,81 @@
         "extensions": {
           "futureTransportMetadata": {}
         }
+      },
+      {
+        "id": "mcp:claude_code:project_shared:filesystem",
+        "logicalId": "mcp:claude_code:filesystem",
+        "clientId": "client:claude_code:default",
+        "name": "filesystem",
+        "enabled": true,
+        "transport": {
+          "kind": "stdio",
+          "command": "npx",
+          "args": [
+            "-y",
+            "@modelcontextprotocol/server-filesystem",
+            "/Users/fengliu/Code/ai-manager"
+          ]
+        },
+        "env": [],
+        "source": {
+          "origin": "mcp_config",
+          "path": "{projectRoot}/.mcp.json#/mcpServers/filesystem",
+          "containerPath": "{projectRoot}/.mcp.json",
+          "sourceId": "mcp::claude_code::project_shared::{projectRoot}/.mcp.json#/mcpServers",
+          "scope": "project_shared",
+          "label": "Project config",
+          "isEffective": true,
+          "shadowedBy": null,
+          "line": 4,
+          "column": 7,
+          "warnings": []
+        },
+        "raw": {
+          "providerSpecific": {
+            "managedBy": "repository"
+          }
+        },
+        "extensions": {
+          "futureTransportMetadata": {}
+        }
+      },
+      {
+        "id": "mcp:codex:user:github",
+        "logicalId": "mcp:codex:github",
+        "clientId": "client:codex:default",
+        "name": "github",
+        "enabled": true,
+        "transport": {
+          "kind": "streamable_http",
+          "url": "https://api.githubcopilot.com/mcp/"
+        },
+        "env": [],
+        "source": {
+          "origin": "mcp_config",
+          "path": "~/.codex/config.toml#servers.github",
+          "containerPath": "~/.codex/config.toml",
+          "sourceId": "mcp::codex::user::~/.codex/config.toml#servers",
+          "scope": "user",
+          "label": "Personal config",
+          "isEffective": true,
+          "shadowedBy": null,
+          "warnings": []
+        },
+        "raw": {
+          "providerSpecific": {
+            "table": "servers.github"
+          }
+        },
+        "extensions": {
+          "futureTransportMetadata": {}
+        }
       }
     ],
     "skills": [
       {
-        "id": "skill:cursor:python-refactor",
+        "id": "skill:cursor:user:python-refactor",
+        "logicalId": "skill:cursor:python-refactor",
         "clientId": "client:cursor:default",
         "name": "python-refactor",
         "enabled": true,
@@ -111,6 +308,12 @@
         "source": {
           "origin": "skills_dir",
           "path": "~/.cursor/skills/python-refactor/SKILL.md",
+          "containerPath": "~/.cursor/skills",
+          "sourceId": "skill::cursor::user::~/.cursor/skills",
+          "scope": "user",
+          "label": "Personal skills",
+          "isEffective": true,
+          "shadowedBy": null,
           "warnings": []
         },
         "raw": {

--- a/docs/spec/support-matrix.md
+++ b/docs/spec/support-matrix.md
@@ -1,6 +1,6 @@
 # Support Matrix v1
 
-This document freezes the detection input matrix for MVP issue `#10`.
+This document freezes the detection input matrix and staged scope rollout plan for issues `#106` and `#114`.
 
 ## Scope
 
@@ -11,6 +11,8 @@ This document freezes the detection input matrix for MVP issue `#10`.
 - Required matrix artifacts:
   - Binary candidate order (for CLI-first clients)
   - Config and skills path candidate order
+  - Current vs target scope support per resource kind
+  - Effective precedence order for source-aware listing
   - Detection evidence requirements per client
   - Path precedence policy and fallback behavior
 
@@ -22,6 +24,16 @@ This document freezes the detection input matrix for MVP issue `#10`.
    - more-specific OS match first
    - then lexical `path` order
 4. If one candidate fails, continue to the next candidate in the same `kind`.
+
+## Staged Scope Support
+
+- `resourceKinds.mcp` captures current vs target MCP scope support per client.
+- `resourceKinds.skills` stays user-only for now and records that project scope is deferred.
+- `projectScopeStatus` values are:
+  - `planned`: native project support is intended in a follow-up implementation issue
+  - `deferred`: project scope is intentionally postponed pending taxonomy/product decisions
+  - `not_applicable`: no native upstream project support is assumed
+- `effectivePrecedence` records the scope ordering the UI/backend should use once the target scopes are enabled.
 
 ## Happy Path and Fallback
 

--- a/docs/spec/support-matrix.v1.json
+++ b/docs/spec/support-matrix.v1.json
@@ -1,9 +1,9 @@
 {
   "$schema": "../../schemas/support-matrix.schema.json",
-  "version": "1.0.0",
-  "updatedAt": "2026-03-04",
+  "version": "1.1.0",
+  "updatedAt": "2026-03-08",
   "resolutionPolicy": {
-    "precedence": "ascending_priority_per_kind",
+    "precedence": "per_resource_kind_scope_order_then_candidate_priority",
     "tieBreaker": "more_specific_os_match_then_lexicographic_path",
     "fallbackStrategy": "continue_to_next_candidate_until_exhausted"
   },
@@ -97,6 +97,57 @@
           "role": "fallback"
         }
       ],
+      "resourceKinds": {
+        "mcp": {
+          "currentSourceScopes": [
+            "user"
+          ],
+          "targetSourceScopes": [
+            "user",
+            "project_shared",
+            "project_private"
+          ],
+          "currentDestinationScopes": [
+            "user"
+          ],
+          "targetDestinationScopes": [
+            "user",
+            "project_shared",
+            "project_private"
+          ],
+          "effectivePrecedence": [
+            "project_private",
+            "project_shared",
+            "user"
+          ],
+          "projectScopeStatus": "planned",
+          "notes": [
+            "Project-shared MCP is sourced from {projectRoot}/.mcp.json.",
+            "Project-private MCP is sourced from ~/.claude.json under projects[{canonicalProjectRoot}].mcpServers."
+          ]
+        },
+        "skills": {
+          "currentSourceScopes": [
+            "user"
+          ],
+          "targetSourceScopes": [
+            "user"
+          ],
+          "currentDestinationScopes": [
+            "user"
+          ],
+          "targetDestinationScopes": [
+            "user"
+          ],
+          "effectivePrecedence": [
+            "user"
+          ],
+          "projectScopeStatus": "deferred",
+          "notes": [
+            "Claude project-scoped customization should be clarified via subagents in issue #110 before adding native project support."
+          ]
+        }
+      },
       "detectionEvidenceRequirements": [
         "binary_resolves",
         "mcp_config_readable",
@@ -185,6 +236,50 @@
           "role": "fallback"
         }
       ],
+      "resourceKinds": {
+        "mcp": {
+          "currentSourceScopes": [
+            "user"
+          ],
+          "targetSourceScopes": [
+            "user"
+          ],
+          "currentDestinationScopes": [
+            "user"
+          ],
+          "targetDestinationScopes": [
+            "user"
+          ],
+          "effectivePrecedence": [
+            "user"
+          ],
+          "projectScopeStatus": "not_applicable",
+          "notes": [
+            "Codex remains user-only until official upstream project-local MCP support exists."
+          ]
+        },
+        "skills": {
+          "currentSourceScopes": [
+            "user"
+          ],
+          "targetSourceScopes": [
+            "user"
+          ],
+          "currentDestinationScopes": [
+            "user"
+          ],
+          "targetDestinationScopes": [
+            "user"
+          ],
+          "effectivePrecedence": [
+            "user"
+          ],
+          "projectScopeStatus": "deferred",
+          "notes": [
+            "No native project-scoped skills source is documented for Codex. Generic repository handling remains separate from native support."
+          ]
+        }
+      },
       "detectionEvidenceRequirements": [
         "app_install_present",
         "mcp_config_readable",
@@ -291,6 +386,53 @@
           "role": "fallback"
         }
       ],
+      "resourceKinds": {
+        "mcp": {
+          "currentSourceScopes": [
+            "user"
+          ],
+          "targetSourceScopes": [
+            "user",
+            "project_shared"
+          ],
+          "currentDestinationScopes": [
+            "user"
+          ],
+          "targetDestinationScopes": [
+            "user",
+            "project_shared"
+          ],
+          "effectivePrecedence": [
+            "project_shared",
+            "user"
+          ],
+          "projectScopeStatus": "planned",
+          "notes": [
+            "Cursor project-scoped MCP is sourced from {projectRoot}/.cursor/mcp.json."
+          ]
+        },
+        "skills": {
+          "currentSourceScopes": [
+            "user"
+          ],
+          "targetSourceScopes": [
+            "user"
+          ],
+          "currentDestinationScopes": [
+            "user"
+          ],
+          "targetDestinationScopes": [
+            "user"
+          ],
+          "effectivePrecedence": [
+            "user"
+          ],
+          "projectScopeStatus": "deferred",
+          "notes": [
+            "Project-scoped skills remain deferred until the product taxonomy is clarified in issue #110."
+          ]
+        }
+      },
       "detectionEvidenceRequirements": [
         "mcp_config_readable",
         "skills_dir_accessible",

--- a/schemas/normalized-domain-model.schema.json
+++ b/schemas/normalized-domain-model.schema.json
@@ -48,7 +48,15 @@
     }
   },
   "$defs": {
-    "sourceMetadata": {
+    "resourceSourceScope": {
+      "type": "string",
+      "enum": [
+        "user",
+        "project_shared",
+        "project_private"
+      ]
+    },
+    "traceSourceMetadata": {
       "type": "object",
       "required": [
         "origin",
@@ -79,6 +87,105 @@
           "items": {
             "type": "string"
           }
+        }
+      },
+      "additionalProperties": false
+    },
+    "resourceScopeSupport": {
+      "type": "object",
+      "required": [
+        "currentSourceScopes",
+        "targetSourceScopes",
+        "currentDestinationScopes",
+        "targetDestinationScopes"
+      ],
+      "properties": {
+        "currentSourceScopes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/resourceSourceScope"
+          }
+        },
+        "targetSourceScopes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/resourceSourceScope"
+          }
+        },
+        "currentDestinationScopes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/resourceSourceScope"
+          }
+        },
+        "targetDestinationScopes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/resourceSourceScope"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "resourceSourceMetadata": {
+      "type": "object",
+      "required": [
+        "origin",
+        "path",
+        "warnings",
+        "containerPath",
+        "sourceId",
+        "scope",
+        "label",
+        "isEffective",
+        "shadowedBy"
+      ],
+      "properties": {
+        "origin": {
+          "type": "string",
+          "enum": [
+            "detector",
+            "mcp_config",
+            "skills_dir"
+          ]
+        },
+        "path": {
+          "type": "string"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "column": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "containerPath": {
+          "type": "string"
+        },
+        "sourceId": {
+          "type": "string"
+        },
+        "scope": {
+          "$ref": "#/$defs/resourceSourceScope"
+        },
+        "label": {
+          "type": "string"
+        },
+        "isEffective": {
+          "type": "boolean"
+        },
+        "shadowedBy": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false
@@ -123,7 +230,8 @@
           "required": [
             "supportsMcp",
             "supportsSkills",
-            "supportsEnableDisable"
+            "supportsEnableDisable",
+            "scopeSupport"
           ],
           "properties": {
             "supportsMcp": {
@@ -134,12 +242,28 @@
             },
             "supportsEnableDisable": {
               "type": "boolean"
+            },
+            "scopeSupport": {
+              "type": "object",
+              "required": [
+                "mcp",
+                "skills"
+              ],
+              "properties": {
+                "mcp": {
+                  "$ref": "#/$defs/resourceScopeSupport"
+                },
+                "skills": {
+                  "$ref": "#/$defs/resourceScopeSupport"
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
         "source": {
-          "$ref": "#/$defs/sourceMetadata"
+          "$ref": "#/$defs/traceSourceMetadata"
         },
         "raw": {
           "type": "object"
@@ -212,6 +336,7 @@
       "type": "object",
       "required": [
         "id",
+        "logicalId",
         "clientId",
         "name",
         "enabled",
@@ -222,6 +347,9 @@
       ],
       "properties": {
         "id": {
+          "type": "string"
+        },
+        "logicalId": {
           "type": "string"
         },
         "clientId": {
@@ -243,7 +371,7 @@
           }
         },
         "source": {
-          "$ref": "#/$defs/sourceMetadata"
+          "$ref": "#/$defs/resourceSourceMetadata"
         },
         "raw": {
           "type": "object"
@@ -282,6 +410,7 @@
       "type": "object",
       "required": [
         "id",
+        "logicalId",
         "clientId",
         "name",
         "enabled",
@@ -292,6 +421,9 @@
       ],
       "properties": {
         "id": {
+          "type": "string"
+        },
+        "logicalId": {
           "type": "string"
         },
         "clientId": {
@@ -328,7 +460,7 @@
           "additionalProperties": false
         },
         "source": {
-          "$ref": "#/$defs/sourceMetadata"
+          "$ref": "#/$defs/resourceSourceMetadata"
         },
         "raw": {
           "type": "object"

--- a/schemas/support-matrix.schema.json
+++ b/schemas/support-matrix.schema.json
@@ -49,6 +49,7 @@
           "category",
           "binaryCandidates",
           "configPathCandidates",
+          "resourceKinds",
           "detectionEvidenceRequirements",
           "assumptions"
         ],
@@ -144,6 +145,22 @@
               "additionalProperties": false
             }
           },
+          "resourceKinds": {
+            "type": "object",
+            "required": [
+              "mcp",
+              "skills"
+            ],
+            "properties": {
+              "mcp": {
+                "$ref": "#/$defs/resourceKindSupport"
+              },
+              "skills": {
+                "$ref": "#/$defs/resourceKindSupport"
+              }
+            },
+            "additionalProperties": false
+          },
           "detectionEvidenceRequirements": {
             "type": "array",
             "minItems": 2,
@@ -161,6 +178,77 @@
         },
         "additionalProperties": false
       }
+    }
+  },
+  "$defs": {
+    "resourceSourceScope": {
+      "type": "string",
+      "enum": [
+        "user",
+        "project_shared",
+        "project_private"
+      ]
+    },
+    "resourceKindSupport": {
+      "type": "object",
+      "required": [
+        "currentSourceScopes",
+        "targetSourceScopes",
+        "currentDestinationScopes",
+        "targetDestinationScopes",
+        "effectivePrecedence",
+        "projectScopeStatus",
+        "notes"
+      ],
+      "properties": {
+        "currentSourceScopes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/resourceSourceScope"
+          }
+        },
+        "targetSourceScopes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/resourceSourceScope"
+          }
+        },
+        "currentDestinationScopes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/resourceSourceScope"
+          }
+        },
+        "targetDestinationScopes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/resourceSourceScope"
+          }
+        },
+        "effectivePrecedence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/resourceSourceScope"
+          }
+        },
+        "projectScopeStatus": {
+          "type": "string",
+          "enum": [
+            "planned",
+            "deferred",
+            "not_applicable"
+          ]
+        },
+        "notes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Tests
 
-The test suite is intentionally minimal and focuses only on stable contract invariants.
+The test suite is intentionally minimal and focuses on stable contract invariants for the current source-aware rollout.
 
 ## Included Tests
 
@@ -12,6 +12,7 @@ The test suite is intentionally minimal and focuses only on stable contract inva
 ## Why These Only
 
 - They validate JSON contract structure and consistency.
+- They pin staged support assumptions such as `current*Scopes` vs `target*Scopes`.
 - They are less brittle than source-text UI/implementation guards.
 - They keep maintenance cost low while preserving core compatibility checks.
 

--- a/tests/normalized-domain-model.test.mjs
+++ b/tests/normalized-domain-model.test.mjs
@@ -8,9 +8,10 @@ const model = JSON.parse(readFileSync(modelPath, "utf8"));
 const clientTypeSet = new Set(["claude_code", "codex", "cursor"]);
 const transportKindSet = new Set(["stdio", "http", "sse", "streamable_http"]);
 const skillInstallKindSet = new Set(["file", "directory", "reference"]);
+const sourceScopeSet = new Set(["user", "project_shared", "project_private"]);
 
 test("domain model envelope version and entity groups are present", () => {
-  assert.equal(model.version, "1.0.0");
+  assert.equal(model.version, "1.1.0");
   assert.ok(model.entities);
   assert.ok(Array.isArray(model.entities.clients));
   assert.ok(Array.isArray(model.entities.mcps));
@@ -26,6 +27,16 @@ test("client entities expose capability flags and extension points", () => {
     assert.equal(typeof client.capabilities.supportsMcp, "boolean");
     assert.equal(typeof client.capabilities.supportsSkills, "boolean");
     assert.equal(typeof client.capabilities.supportsEnableDisable, "boolean");
+    for (const kind of ["mcp", "skills"]) {
+      const support = client.capabilities.scopeSupport[kind];
+      assert.ok(Array.isArray(support.currentSourceScopes));
+      assert.ok(Array.isArray(support.targetSourceScopes));
+      assert.ok(Array.isArray(support.currentDestinationScopes));
+      assert.ok(Array.isArray(support.targetDestinationScopes));
+      for (const scope of support.targetSourceScopes) {
+        assert.ok(sourceScopeSet.has(scope), `unsupported ${kind} source scope: ${scope}`);
+      }
+    }
     assert.equal(typeof client.extensions, "object");
     assert.equal(typeof client.raw, "object");
   }
@@ -33,12 +44,22 @@ test("client entities expose capability flags and extension points", () => {
 
 test("mcp entities include transport model, source metadata and raw payload", () => {
   for (const mcp of model.entities.mcps) {
+    assert.equal(typeof mcp.logicalId, "string");
     assert.ok(
       transportKindSet.has(mcp.transport.kind),
       `unsupported transport: ${mcp.transport.kind}`,
     );
     assert.equal(typeof mcp.source.origin, "string");
     assert.equal(typeof mcp.source.path, "string");
+    assert.equal(typeof mcp.source.containerPath, "string");
+    assert.equal(typeof mcp.source.sourceId, "string");
+    assert.ok(sourceScopeSet.has(mcp.source.scope), `unsupported scope: ${mcp.source.scope}`);
+    assert.equal(typeof mcp.source.label, "string");
+    assert.equal(typeof mcp.source.isEffective, "boolean");
+    assert.ok(
+      typeof mcp.source.shadowedBy === "string" || mcp.source.shadowedBy === null,
+      "shadowedBy must be string or null",
+    );
     assert.equal(typeof mcp.extensions, "object");
     assert.equal(typeof mcp.raw, "object");
     assert.ok(Array.isArray(mcp.env));
@@ -47,6 +68,7 @@ test("mcp entities include transport model, source metadata and raw payload", ()
 
 test("skill entities include install model, metadata and raw payload", () => {
   for (const skill of model.entities.skills) {
+    assert.equal(typeof skill.logicalId, "string");
     assert.ok(
       skillInstallKindSet.has(skill.install.kind),
       `unsupported install kind: ${skill.install.kind}`,
@@ -54,9 +76,27 @@ test("skill entities include install model, metadata and raw payload", () => {
     assert.equal(typeof skill.install.path, "string");
     assert.ok(Array.isArray(skill.metadata.tags));
     assert.equal(typeof skill.source.path, "string");
+    assert.equal(typeof skill.source.sourceId, "string");
+    assert.ok(sourceScopeSet.has(skill.source.scope), `unsupported scope: ${skill.source.scope}`);
     assert.equal(typeof skill.extensions, "object");
     assert.equal(typeof skill.raw, "object");
   }
+});
+
+test("source-aware ids allow one logical resource to appear in multiple sources", () => {
+  const byLogicalId = new Map();
+
+  for (const mcp of model.entities.mcps) {
+    const entries = byLogicalId.get(mcp.logicalId) ?? [];
+    entries.push(mcp.id);
+    byLogicalId.set(mcp.logicalId, entries);
+    assert.notEqual(mcp.id, mcp.logicalId, "source-aware id should differ from logical id");
+  }
+
+  assert.deepEqual(byLogicalId.get("mcp:claude_code:filesystem"), [
+    "mcp:claude_code:user:filesystem",
+    "mcp:claude_code:project_shared:filesystem",
+  ]);
 });
 
 test("cross-entity references are consistent", () => {

--- a/tests/support-matrix.test.mjs
+++ b/tests/support-matrix.test.mjs
@@ -6,6 +6,7 @@ const matrixPath = new URL("../docs/spec/support-matrix.v1.json", import.meta.ur
 const matrix = JSON.parse(readFileSync(matrixPath, "utf8"));
 
 const expectedClientIds = ["claude_code", "codex", "cursor"];
+const sourceScopeSet = new Set(["user", "project_shared", "project_private"]);
 
 function assertContiguousPriorities(candidates, fieldName) {
   const priorities = candidates.map((candidate) => candidate.priority).sort((a, b) => a - b);
@@ -18,7 +19,7 @@ function assertContiguousPriorities(candidates, fieldName) {
 }
 
 test("matrix includes exactly three target clients", () => {
-  assert.equal(matrix.version, "1.0.0");
+  assert.equal(matrix.version, "1.1.0");
   assert.equal(matrix.clients.length, expectedClientIds.length);
   assert.deepEqual(matrix.clients.map((client) => client.id).sort(), [...expectedClientIds].sort());
 });
@@ -59,4 +60,51 @@ test("detection requirements are actionable and include config readability", () 
       `${client.id} must have at least two detection requirements`,
     );
   }
+});
+
+test("resource kinds expose staged scope support and precedence", () => {
+  for (const client of matrix.clients) {
+    for (const kind of ["mcp", "skills"]) {
+      const support = client.resourceKinds[kind];
+      assert.ok(Array.isArray(support.currentSourceScopes));
+      assert.ok(Array.isArray(support.targetSourceScopes));
+      assert.ok(Array.isArray(support.currentDestinationScopes));
+      assert.ok(Array.isArray(support.targetDestinationScopes));
+      assert.ok(Array.isArray(support.effectivePrecedence));
+      assert.ok(Array.isArray(support.notes));
+
+      for (const scope of support.targetSourceScopes) {
+        assert.ok(sourceScopeSet.has(scope), `unsupported ${client.id}/${kind} scope: ${scope}`);
+      }
+
+      assert.ok(
+        support.targetSourceScopes.includes(support.effectivePrecedence[0]),
+        `${client.id}/${kind} precedence must start with a supported scope`,
+      );
+      assert.ok(
+        support.currentSourceScopes.every((scope) => support.targetSourceScopes.includes(scope)),
+        `${client.id}/${kind} current scopes must be a subset of target scopes`,
+      );
+    }
+  }
+});
+
+test("staged MCP support matches the client rollout plan", () => {
+  const byId = new Map(matrix.clients.map((client) => [client.id, client]));
+
+  assert.deepEqual(byId.get("claude_code").resourceKinds.mcp.targetSourceScopes, [
+    "user",
+    "project_shared",
+    "project_private",
+  ]);
+  assert.equal(byId.get("claude_code").resourceKinds.mcp.projectScopeStatus, "planned");
+
+  assert.deepEqual(byId.get("cursor").resourceKinds.mcp.targetSourceScopes, [
+    "user",
+    "project_shared",
+  ]);
+  assert.equal(byId.get("cursor").resourceKinds.mcp.projectScopeStatus, "planned");
+
+  assert.deepEqual(byId.get("codex").resourceKinds.mcp.targetSourceScopes, ["user"]);
+  assert.equal(byId.get("codex").resourceKinds.mcp.projectScopeStatus, "not_applicable");
 });


### PR DESCRIPTION
## Summary
- refresh the normalized domain model sample and schema to document source-aware ids, source metadata, and staged scope support
- extend the support matrix sample and schema with current vs target scope rollout details for Claude, Cursor, and Codex
- tighten contract tests and test docs around staged source-aware assumptions

## Verification
- `pnpm test`
- `pnpm run lint`
- `pnpm run ci:web`
- `pnpm outdated` (reported newer `@biomejs/biome` 2.4.6 and `@tauri-apps/cli` 2.10.1)

Closes #114