### PR TITLE
feat: support project-aware MCP mutation targets

### DIFF
--- a/src-tauri/src/application/adapter_service.rs
+++ b/src-tauri/src/application/adapter_service.rs
@@ -95,7 +95,7 @@ impl<'a> AdapterService<'a> {
         &self,
         request: &MutateResourceRequest,
     ) -> Result<MutateResourceResponse, CommandError> {
-        let _project_root =
+        let project_root =
             ProjectContextResolver::new().resolve(request.project_root.as_deref())?;
         let target_id = request.target_id.trim();
 
@@ -152,6 +152,8 @@ impl<'a> AdapterService<'a> {
                 request.client,
                 request.action,
                 target_id,
+                project_root.as_deref(),
+                request.target_source_id.as_deref(),
                 request.payload.as_ref(),
             )?;
 
@@ -161,7 +163,7 @@ impl<'a> AdapterService<'a> {
                 target_id: target_id.to_string(),
                 message: outcome.message,
                 source_path: Some(outcome.source_path),
-                target_source_id: request.target_source_id.clone(),
+                target_source_id: Some(outcome.target_source_id),
             });
         }
 
@@ -518,7 +520,10 @@ mod tests {
                 action: MutationAction::Add,
                 target_id: "filesystem".to_string(),
                 project_root: None,
-                target_source_id: Some("mcp::user::/tmp/claude.json".to_string()),
+                target_source_id: Some(format!(
+                    "mcp::claude_code::user::{}::/mcpServers",
+                    source.display()
+                )),
                 payload: Some(json!({
                     "source_path": source.display().to_string(),
                     "transport": { "command": "npx", "args": ["-y", "server"] },
@@ -529,6 +534,8 @@ mod tests {
 
         let content = fs::read_to_string(&source).expect("should read updated target");
         let expected_source_path = source.display().to_string();
+        let expected_target_source_id =
+            format!("mcp::claude_code::user::{}::/mcpServers", source.display());
         let _ = fs::remove_dir_all(&temp_dir);
 
         assert!(response.accepted);
@@ -539,7 +546,7 @@ mod tests {
         );
         assert_eq!(
             response.target_source_id.as_deref(),
-            Some("mcp::user::/tmp/claude.json")
+            Some(expected_target_source_id.as_str())
         );
         assert!(content.contains("filesystem"));
     }

--- a/src-tauri/src/application/critical_paths_suite.rs
+++ b/src-tauri/src/application/critical_paths_suite.rs
@@ -114,6 +114,8 @@ fn mcp_mutation_round_trip_covers_success_and_failure_paths() {
             ClientKind::Cursor,
             MutationAction::Add,
             "filesystem",
+            None,
+            None,
             Some(&json!({
                 "source_path": config_path.display().to_string(),
                 "transport": {
@@ -135,6 +137,8 @@ fn mcp_mutation_round_trip_covers_success_and_failure_paths() {
             ClientKind::Cursor,
             MutationAction::Update,
             "filesystem",
+            None,
+            None,
             Some(&json!({
                 "source_path": config_path.display().to_string(),
                 "transport": {
@@ -155,6 +159,8 @@ fn mcp_mutation_round_trip_covers_success_and_failure_paths() {
             ClientKind::Cursor,
             MutationAction::Remove,
             "filesystem",
+            None,
+            None,
             Some(&json!({ "source_path": config_path.display().to_string() })),
         )
         .expect("MCP remove should succeed");
@@ -169,6 +175,8 @@ fn mcp_mutation_round_trip_covers_success_and_failure_paths() {
             ClientKind::Cursor,
             MutationAction::Remove,
             "filesystem",
+            None,
+            None,
             Some(&json!({ "source_path": config_path.display().to_string() })),
         )
         .expect_err("removing a missing MCP should be actionable validation failure");

--- a/src-tauri/src/application/mcp/mod.rs
+++ b/src-tauri/src/application/mcp/mod.rs
@@ -2,4 +2,5 @@ pub(super) mod config_path_resolver;
 pub(super) mod listing_service;
 pub(super) mod mutation_payload;
 pub(super) mod mutation_service;
+pub(super) mod mutation_target_resolver;
 pub(super) mod source_catalog_service;

--- a/src-tauri/src/application/mcp/mutation_service.rs
+++ b/src-tauri/src/application/mcp/mutation_service.rs
@@ -7,13 +7,15 @@ use crate::{
 };
 
 use super::{
-    config_path_resolver::resolve_mcp_config_path,
     mutation_payload::{McpMutationPayload, McpTransportPayload, parse_mcp_mutation_payload},
+    mutation_target_resolver::McpMutationTargetResolver,
+    source_catalog_service::{McpSourceDescriptor, McpSourceStorageKind},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct McpMutationResult {
     pub source_path: String,
+    pub target_source_id: String,
     pub message: String,
 }
 
@@ -31,36 +33,46 @@ impl<'a> McpMutationService<'a> {
         client: ClientKind,
         action: MutationAction,
         target_id: &str,
+        project_root: Option<&str>,
+        target_source_id: Option<&str>,
         payload: Option<&serde_json::Value>,
     ) -> Result<McpMutationResult, CommandError> {
         let payload = parse_mcp_mutation_payload(action, payload)?;
-        let source_path = resolve_mcp_config_path(
+        let target_descriptor = McpMutationTargetResolver::new(self.detector_registry).resolve(
             client,
             action,
+            project_root,
+            target_source_id,
             payload.source_path.as_deref(),
-            self.detector_registry,
         )?;
 
-        let current_content = match fs::read_to_string(&source_path) {
+        let current_content = match fs::read_to_string(&target_descriptor.container_path) {
             Ok(content) => content,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
             Err(error) => {
                 return Err(CommandError::internal(format!(
                     "Failed to read MCP config '{}': {}",
-                    source_path.display(),
+                    target_descriptor.container_path.display(),
                     error
                 )));
             }
         };
 
-        let next_content = if matches!(client, ClientKind::Codex) {
-            mutate_toml_content(&current_content, target_id, action, &payload)?
-        } else {
-            mutate_json_content(client, &current_content, target_id, action, &payload)?
+        let next_content = match target_descriptor.storage_kind {
+            McpSourceStorageKind::JsonSection => mutate_json_content(
+                &target_descriptor,
+                &current_content,
+                target_id,
+                action,
+                &payload,
+            )?,
+            McpSourceStorageKind::TomlTable => {
+                mutate_toml_content(&current_content, target_id, action, &payload)?
+            }
         };
 
         let write_result = SafeFileMutator::new()
-            .replace_file(&source_path, next_content.as_bytes())
+            .replace_file(&target_descriptor.container_path, next_content.as_bytes())
             .map_err(|failure| {
                 CommandError::internal(format!(
                     "[stage={:?}] {} (rollback_succeeded={})",
@@ -69,27 +81,39 @@ impl<'a> McpMutationService<'a> {
             })?;
 
         let mut message = match action {
-            MutationAction::Add => format!("Added MCP '{}' for '{}'.", target_id, client.as_str()),
-            MutationAction::Remove => {
-                format!("Removed MCP '{}' for '{}'.", target_id, client.as_str())
-            }
-            MutationAction::Update => {
-                format!("Updated MCP '{}' for '{}'.", target_id, client.as_str())
-            }
+            MutationAction::Add => format!(
+                "Added MCP '{}' for '{}' in {}.",
+                target_id,
+                client.as_str(),
+                target_descriptor.source_label
+            ),
+            MutationAction::Remove => format!(
+                "Removed MCP '{}' for '{}' from {}.",
+                target_id,
+                client.as_str(),
+                target_descriptor.source_label
+            ),
+            MutationAction::Update => format!(
+                "Updated MCP '{}' for '{}' in {}.",
+                target_id,
+                client.as_str(),
+                target_descriptor.source_label
+            ),
         };
         if let Some(backup_path) = write_result.backup_path {
             message.push_str(&format!(" Backup: {}.", backup_path));
         }
 
         Ok(McpMutationResult {
-            source_path: source_path.display().to_string(),
+            source_path: target_descriptor.container_path.display().to_string(),
+            target_source_id: target_descriptor.source_id,
             message,
         })
     }
 }
 
 fn mutate_json_content(
-    client: ClientKind,
+    descriptor: &McpSourceDescriptor,
     current_content: &str,
     target_id: &str,
     action: MutationAction,
@@ -103,13 +127,20 @@ fn mutate_json_content(
         })?
     };
 
-    let Some(root_object) = root.as_object_mut() else {
+    if !root.is_object() {
         return Err(CommandError::validation(
             "JSON MCP config root must be an object.",
         ));
-    };
-    let section_object = resolve_mcp_section_map(root_object)?;
-    apply_json_mcp_mutation(client, section_object, target_id, action, payload)?;
+    }
+
+    let section_object = resolve_json_section_map(&mut root, &descriptor.selector)?;
+    apply_json_mcp_mutation(
+        descriptor.client,
+        section_object,
+        target_id,
+        action,
+        payload,
+    )?;
 
     let mut serialized = serde_json::to_string_pretty(&root).map_err(|error| {
         CommandError::internal(format!("Failed to serialize JSON MCP config: {}", error))
@@ -118,26 +149,12 @@ fn mutate_json_content(
     Ok(serialized)
 }
 
-fn resolve_mcp_section_map(
-    object: &mut serde_json::Map<String, serde_json::Value>,
-) -> Result<&mut serde_json::Map<String, serde_json::Value>, CommandError> {
-    let section_key = if object.contains_key("mcpServers") {
-        "mcpServers"
-    } else if object.contains_key("mcp_servers") {
-        "mcp_servers"
-    } else {
-        "mcpServers"
-    };
-
-    if !object.contains_key(section_key) {
-        object.insert(section_key.to_string(), serde_json::json!({}));
-    }
-
-    let Some(section) = object.get_mut(section_key) else {
-        return Err(CommandError::validation(
-            "JSON MCP section could not be resolved.",
-        ));
-    };
+fn resolve_json_section_map<'a>(
+    root: &'a mut serde_json::Value,
+    selector: &str,
+) -> Result<&'a mut serde_json::Map<String, serde_json::Value>, CommandError> {
+    let tokens = parse_json_pointer_tokens(selector)?;
+    let section = resolve_json_section_value(root, &tokens)?;
     let Some(section_object) = section.as_object_mut() else {
         return Err(CommandError::validation(
             "JSON MCP section must be an object map.",
@@ -145,6 +162,61 @@ fn resolve_mcp_section_map(
     };
 
     Ok(section_object)
+}
+
+fn parse_json_pointer_tokens(selector: &str) -> Result<Vec<String>, CommandError> {
+    if !selector.starts_with('/') {
+        return Err(CommandError::validation(format!(
+            "JSON MCP selector '{}' must start with '/'.",
+            selector
+        )));
+    }
+
+    Ok(selector
+        .split('/')
+        .skip(1)
+        .map(|token| token.replace("~1", "/").replace("~0", "~"))
+        .collect())
+}
+
+fn resolve_json_section_value<'a>(
+    current: &'a mut serde_json::Value,
+    tokens: &[String],
+) -> Result<&'a mut serde_json::Value, CommandError> {
+    if tokens.is_empty() {
+        return Ok(current);
+    }
+
+    let Some(object) = current.as_object_mut() else {
+        return Err(CommandError::validation(
+            "JSON MCP path contains a non-object segment.",
+        ));
+    };
+
+    let key = resolve_json_child_key(object, &tokens[0]);
+    let next = object.entry(key).or_insert_with(|| serde_json::json!({}));
+
+    resolve_json_section_value(next, &tokens[1..])
+}
+
+fn resolve_json_child_key(
+    object: &serde_json::Map<String, serde_json::Value>,
+    requested_key: &str,
+) -> String {
+    if requested_key == "mcpServers" {
+        if object.contains_key("mcpServers") {
+            return "mcpServers".to_string();
+        }
+        if object.contains_key("mcp_servers") {
+            return "mcp_servers".to_string();
+        }
+    }
+
+    if requested_key == "mcp_servers" && object.contains_key("mcpServers") {
+        return "mcpServers".to_string();
+    }
+
+    requested_key.to_string()
 }
 
 fn apply_json_mcp_mutation(
@@ -397,7 +469,7 @@ fn build_toml_transport_payload(transport: &McpTransportPayload, enabled: bool) 
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{fs, path::PathBuf};
 
     use serde_json::{Value, json};
 
@@ -423,6 +495,8 @@ mod tests {
                 ClientKind::ClaudeCode,
                 MutationAction::Add,
                 "filesystem",
+                None,
+                None,
                 Some(&json!({
                     "source_path": source.display().to_string(),
                     "transport": { "command": "npx", "args": ["-y", "server"] },
@@ -484,6 +558,8 @@ mod tests {
                 ClientKind::ClaudeCode,
                 MutationAction::Add,
                 "filesystem",
+                None,
+                None,
                 Some(&json!({
                     "source_path": source.display().to_string(),
                     "transport": { "command": "npx", "args": ["-y", "server"] },
@@ -546,6 +622,8 @@ mod tests {
                 ClientKind::ClaudeCode,
                 MutationAction::Add,
                 "filesystem",
+                None,
+                None,
                 Some(&json!({
                     "source_path": source.display().to_string(),
                     "transport": { "command": "npx", "args": ["-y", "server"] },
@@ -597,6 +675,8 @@ mod tests {
                 ClientKind::Cursor,
                 MutationAction::Add,
                 "context7",
+                None,
+                None,
                 Some(&json!({
                     "source_path": source.display().to_string(),
                     "transport": { "command": "context7" }
@@ -634,6 +714,8 @@ mod tests {
                 ClientKind::Cursor,
                 MutationAction::Update,
                 "filesystem",
+                None,
+                None,
                 Some(&json!({
                     "source_path": source.display().to_string(),
                     "transport": { "url": "https://mcp.example.com/sse" },
@@ -667,6 +749,8 @@ mod tests {
                 ClientKind::Cursor,
                 MutationAction::Update,
                 "filesystem",
+                None,
+                None,
                 Some(&json!({
                     "source_path": source.display().to_string(),
                     "transport": { "command": "npx" }
@@ -700,6 +784,8 @@ enabled = true
                 ClientKind::Codex,
                 MutationAction::Remove,
                 "filesystem",
+                None,
+                None,
                 Some(&json!({
                     "source_path": source.display().to_string()
                 })),
@@ -713,6 +799,141 @@ enabled = true
     }
 
     #[test]
+    fn claude_project_private_target_mutates_project_section() {
+        let temp_dir = temp_root("claude-project-private");
+        let project_root = temp_dir.join("workspace");
+        let _ = fs::create_dir_all(&project_root);
+        let project_root_string = project_root.display().to_string();
+        let source = temp_dir.join("claude.json");
+        fs::write(
+            &source,
+            r#"{
+  "mcpServers": {
+    "root": { "command": "npx", "enabled": true }
+  }
+}"#,
+        )
+        .expect("should create claude config");
+
+        let target_source_id = format!(
+            "mcp::claude_code::project_private::{}::/projects/{}/mcpServers",
+            source.display(),
+            escape_json_pointer_token(&project_root_string)
+        );
+
+        let detector_registry = DetectorRegistry::with_default_detectors();
+        let service = McpMutationService::new(&detector_registry);
+        let result = service
+            .mutate(
+                ClientKind::ClaudeCode,
+                MutationAction::Add,
+                "github",
+                Some(project_root_string.as_str()),
+                Some(target_source_id.as_str()),
+                Some(&json!({
+                    "source_path": source.display().to_string(),
+                    "transport": { "url": "https://mcp.example.com/sse" },
+                    "enabled": true
+                })),
+            )
+            .expect("project-private add should succeed");
+
+        let content = fs::read_to_string(&source).expect("should read updated config");
+        let value: Value = serde_json::from_str(&content).expect("output should remain valid json");
+        let _ = fs::remove_dir_all(&temp_dir);
+
+        assert!(result.target_source_id.contains("project_private"));
+        assert_eq!(result.source_path, source.display().to_string());
+        assert!(
+            value
+                .get("mcpServers")
+                .and_then(Value::as_object)
+                .is_some_and(|servers| !servers.contains_key("github"))
+        );
+        assert!(
+            value
+                .get("projects")
+                .and_then(Value::as_object)
+                .and_then(|projects| projects.get(project_root_string.as_str()))
+                .and_then(Value::as_object)
+                .and_then(|project| project.get("mcpServers"))
+                .and_then(Value::as_object)
+                .is_some_and(|servers| servers.contains_key("github"))
+        );
+    }
+
+    #[test]
+    fn cursor_project_shared_target_mutates_project_file() {
+        let temp_dir = temp_root("cursor-project-shared");
+        let project_root = temp_dir.join("workspace");
+        let project_config = project_root.join(".cursor").join("mcp.json");
+        let _ = fs::create_dir_all(project_config.parent().expect("project config parent"));
+        fs::write(&project_config, "{}").expect("should create cursor project config");
+        let project_root_string = project_root.display().to_string();
+
+        let target_source_id = format!(
+            "mcp::cursor::project_shared::{}::/mcpServers",
+            project_config.display()
+        );
+
+        let detector_registry = DetectorRegistry::with_default_detectors();
+        let service = McpMutationService::new(&detector_registry);
+        let result = service
+            .mutate(
+                ClientKind::Cursor,
+                MutationAction::Add,
+                "context7",
+                Some(project_root_string.as_str()),
+                Some(target_source_id.as_str()),
+                Some(&json!({
+                    "source_path": project_config.display().to_string(),
+                    "transport": { "command": "context7" },
+                    "enabled": true
+                })),
+            )
+            .expect("project-shared add should succeed");
+
+        let content =
+            fs::read_to_string(&project_config).expect("should read updated project config");
+        let _ = fs::remove_dir_all(&temp_dir);
+
+        assert!(result.target_source_id.contains("project_shared"));
+        assert!(content.contains("\"context7\""));
+        assert!(content.contains("\"enabled\": true"));
+    }
+
+    #[test]
+    fn codex_rejects_project_scoped_target_source() {
+        let temp_dir = temp_root("codex-unsupported-target");
+        let project_root = temp_dir.join("workspace");
+        let _ = fs::create_dir_all(&project_root);
+        let source = temp_dir.join("codex.toml");
+        fs::write(&source, "").expect("should create codex config");
+        let project_root_string = project_root.display().to_string();
+
+        let detector_registry = DetectorRegistry::with_default_detectors();
+        let service = McpMutationService::new(&detector_registry);
+        let error = service
+            .mutate(
+                ClientKind::Codex,
+                MutationAction::Add,
+                "filesystem",
+                Some(project_root_string.as_str()),
+                Some("mcp::codex::project_shared::/tmp/workspace/.codex/config.toml::mcp_servers"),
+                Some(&json!({
+                    "source_path": source.display().to_string(),
+                    "transport": { "command": "npx" },
+                    "enabled": true
+                })),
+            )
+            .expect_err("unsupported codex target should fail");
+
+        let _ = fs::remove_dir_all(&temp_dir);
+
+        assert!(error.message.contains("unsupported scope 'project_shared'"));
+    }
+
+    #[test]
     fn malformed_transport_is_actionable_validation_error() {
         let detector_registry = DetectorRegistry::with_default_detectors();
         let service = McpMutationService::new(&detector_registry);
@@ -721,6 +942,8 @@ enabled = true
                 ClientKind::Codex,
                 MutationAction::Add,
                 "remote",
+                None,
+                None,
                 Some(&json!({
                     "transport": { "url": "ftp://invalid" }
                 })),
@@ -747,6 +970,8 @@ enabled = true
                 ClientKind::ClaudeCode,
                 MutationAction::Add,
                 "filesystem",
+                None,
+                None,
                 Some(&json!({
                     "source_path": source.display().to_string(),
                     "transport": { "command": "npx", "args": ["-y", "server"] },
@@ -757,5 +982,19 @@ enabled = true
         let _ = fs::remove_dir_all(&temp_dir);
 
         assert!(error.message.contains("does not support `enabled=false`"));
+    }
+
+    fn escape_json_pointer_token(value: &str) -> String {
+        value.replace('~', "~0").replace('/', "~1")
+    }
+
+    fn temp_root(suffix: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "ai-manager-mcp-mutation-{}-{}",
+            std::process::id(),
+            suffix
+        ));
+        let _ = fs::create_dir_all(&root);
+        root
     }
 }

--- a/src-tauri/src/application/mcp/mutation_target_resolver.rs
+++ b/src-tauri/src/application/mcp/mutation_target_resolver.rs
@@ -1,0 +1,375 @@
+use std::path::{Path, PathBuf};
+
+use crate::{
+    domain::{ClientKind, ResourceSourceScope},
+    infra::DetectorRegistry,
+    interface::contracts::{command::CommandError, mutate::MutationAction},
+};
+
+use super::{
+    config_path_resolver::resolve_mcp_config_path,
+    source_catalog_service::{
+        McpSourceCatalogService, McpSourceDescriptor, descriptor_for_scope, selector_for_scope,
+        storage_kind_for_client,
+    },
+};
+
+pub struct McpMutationTargetResolver<'a> {
+    detector_registry: &'a DetectorRegistry,
+}
+
+impl<'a> McpMutationTargetResolver<'a> {
+    pub fn new(detector_registry: &'a DetectorRegistry) -> Self {
+        Self { detector_registry }
+    }
+
+    pub fn resolve(
+        &self,
+        client: ClientKind,
+        action: MutationAction,
+        project_root: Option<&str>,
+        target_source_id: Option<&str>,
+        source_path_override: Option<&str>,
+    ) -> Result<McpSourceDescriptor, CommandError> {
+        let source_catalog_service = McpSourceCatalogService::new(self.detector_registry);
+        let descriptors = source_catalog_service.list_sources(client, project_root);
+
+        if let Some(target_source_id) = target_source_id {
+            if let Some(descriptor) = descriptors
+                .iter()
+                .find(|descriptor| descriptor.source_id == target_source_id)
+            {
+                return Ok(descriptor.clone());
+            }
+
+            if let Some(source_path_override) = source_path_override {
+                let override_path = resolve_mcp_config_path(
+                    client,
+                    action,
+                    Some(source_path_override),
+                    self.detector_registry,
+                )?;
+                return build_override_descriptor(
+                    client,
+                    project_root,
+                    target_source_id,
+                    override_path,
+                    &descriptors,
+                );
+            }
+
+            return Err(unresolved_target_source_error(
+                client,
+                target_source_id,
+                &descriptors,
+                project_root.is_some(),
+            ));
+        }
+
+        let source_path =
+            resolve_mcp_config_path(client, action, source_path_override, self.detector_registry)?;
+
+        if let Some(descriptor) = descriptor_for_path(&descriptors, &source_path) {
+            return Ok(descriptor);
+        }
+
+        Ok(descriptor_for_scope(
+            client,
+            ResourceSourceScope::User,
+            source_path,
+            selector_for_scope(client, ResourceSourceScope::User, None),
+            storage_kind_for_client(client),
+            None,
+        ))
+    }
+}
+
+fn build_override_descriptor(
+    client: ClientKind,
+    project_root: Option<&str>,
+    target_source_id: &str,
+    override_path: PathBuf,
+    descriptors: &[McpSourceDescriptor],
+) -> Result<McpSourceDescriptor, CommandError> {
+    let parsed = parse_source_id(target_source_id).ok_or_else(|| {
+        CommandError::validation(format!(
+            "target_source_id '{}' is not a valid MCP source identifier.",
+            target_source_id
+        ))
+    })?;
+
+    if parsed.client != client {
+        return Err(CommandError::validation(format!(
+            "target_source_id '{}' does not belong to '{}'.",
+            target_source_id,
+            client.as_str()
+        )));
+    }
+
+    if parsed.scope != ResourceSourceScope::User && project_root.is_none() {
+        return Err(CommandError::validation(format!(
+            "project_root is required to target '{}' MCP sources.",
+            parsed.scope.as_str()
+        )));
+    }
+
+    if !descriptors
+        .iter()
+        .any(|descriptor| descriptor.source_scope == parsed.scope)
+    {
+        return Err(unsupported_scope_error(
+            client,
+            target_source_id,
+            parsed.scope,
+            descriptors,
+        ));
+    }
+
+    let selector = parsed
+        .selector
+        .unwrap_or_else(|| selector_for_scope(client, parsed.scope, project_root));
+
+    Ok(descriptor_for_scope(
+        client,
+        parsed.scope,
+        override_path,
+        selector,
+        storage_kind_for_client(client),
+        project_root.map(str::to_string),
+    ))
+}
+
+fn descriptor_for_path(
+    descriptors: &[McpSourceDescriptor],
+    source_path: &Path,
+) -> Option<McpSourceDescriptor> {
+    descriptors
+        .iter()
+        .filter(|descriptor| descriptor.container_path == source_path)
+        .min_by_key(|descriptor| legacy_resolution_rank(descriptor.source_scope))
+        .cloned()
+}
+
+fn legacy_resolution_rank(scope: ResourceSourceScope) -> u8 {
+    match scope {
+        ResourceSourceScope::User => 0,
+        ResourceSourceScope::ProjectShared => 1,
+        ResourceSourceScope::ProjectPrivate => 2,
+    }
+}
+
+fn unresolved_target_source_error(
+    client: ClientKind,
+    target_source_id: &str,
+    descriptors: &[McpSourceDescriptor],
+    has_project_root: bool,
+) -> CommandError {
+    if let Some(parsed) = parse_source_id(target_source_id) {
+        if parsed.client != client {
+            return CommandError::validation(format!(
+                "target_source_id '{}' does not belong to '{}'.",
+                target_source_id,
+                client.as_str()
+            ));
+        }
+
+        if parsed.scope != ResourceSourceScope::User && !has_project_root {
+            return CommandError::validation(format!(
+                "project_root is required to target '{}' MCP sources.",
+                parsed.scope.as_str()
+            ));
+        }
+
+        if !descriptors
+            .iter()
+            .any(|descriptor| descriptor.source_scope == parsed.scope)
+        {
+            return unsupported_scope_error(client, target_source_id, parsed.scope, descriptors);
+        }
+    }
+
+    CommandError::validation(format!(
+        "Could not resolve target_source_id '{}' for '{}'.",
+        target_source_id,
+        client.as_str()
+    ))
+}
+
+fn unsupported_scope_error(
+    client: ClientKind,
+    target_source_id: &str,
+    unsupported_scope: ResourceSourceScope,
+    descriptors: &[McpSourceDescriptor],
+) -> CommandError {
+    let supported_scopes = descriptors
+        .iter()
+        .map(|descriptor| descriptor.source_scope.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    CommandError::validation(format!(
+        "target_source_id '{}' requests unsupported scope '{}' for '{}'. Supported scopes: {}.",
+        target_source_id,
+        unsupported_scope.as_str(),
+        client.as_str(),
+        supported_scopes
+    ))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedSourceId {
+    client: ClientKind,
+    scope: ResourceSourceScope,
+    selector: Option<String>,
+}
+
+fn parse_source_id(value: &str) -> Option<ParsedSourceId> {
+    let mut parts = value.splitn(5, "::");
+    let prefix = parts.next()?;
+    let client = parts.next().and_then(parse_client_kind)?;
+    let scope = parts.next().and_then(parse_scope)?;
+    let _path = parts.next()?;
+    let selector = parts.next().map(str::to_string);
+
+    if prefix != "mcp" {
+        return None;
+    }
+
+    Some(ParsedSourceId {
+        client,
+        scope,
+        selector,
+    })
+}
+
+fn parse_client_kind(value: &str) -> Option<ClientKind> {
+    match value {
+        "claude_code" => Some(ClientKind::ClaudeCode),
+        "codex" => Some(ClientKind::Codex),
+        "cursor" => Some(ClientKind::Cursor),
+        _ => None,
+    }
+}
+
+fn parse_scope(value: &str) -> Option<ResourceSourceScope> {
+    match value {
+        "user" => Some(ResourceSourceScope::User),
+        "project_shared" => Some(ResourceSourceScope::ProjectShared),
+        "project_private" => Some(ResourceSourceScope::ProjectPrivate),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::PathBuf};
+
+    use crate::{
+        domain::{ClientKind, ResourceSourceScope},
+        infra::DetectorRegistry,
+        interface::contracts::mutate::MutationAction,
+    };
+
+    use super::McpMutationTargetResolver;
+
+    #[test]
+    fn resolve_prefers_project_shared_descriptor_for_matching_project_file() {
+        let detector_registry = DetectorRegistry::with_default_detectors();
+        let resolver = McpMutationTargetResolver::new(&detector_registry);
+        let project_root = temp_project_root("target-project-shared");
+        let project_config = project_root.join(".cursor").join("mcp.json");
+        fs::create_dir_all(
+            project_config
+                .parent()
+                .expect("project config parent should exist"),
+        )
+        .expect("project config directory should be created");
+        fs::write(&project_config, "{}").expect("project config should be writable");
+
+        let descriptor = resolver
+            .resolve(
+                ClientKind::Cursor,
+                MutationAction::Add,
+                Some(project_root.to_string_lossy().as_ref()),
+                None,
+                Some(project_config.to_string_lossy().as_ref()),
+            )
+            .expect("project-shared descriptor should resolve");
+
+        let _ = fs::remove_dir_all(&project_root);
+
+        assert_eq!(descriptor.source_scope, ResourceSourceScope::ProjectShared);
+        assert_eq!(descriptor.container_path, project_config);
+    }
+
+    #[test]
+    fn resolve_rejects_unsupported_target_scope_for_codex() {
+        let detector_registry = DetectorRegistry::with_default_detectors();
+        let resolver = McpMutationTargetResolver::new(&detector_registry);
+        let project_root = temp_project_root("target-unsupported-scope");
+        let project_source = project_root.join("config.toml");
+        fs::write(&project_source, "").expect("project source should be writable");
+
+        let error = resolver
+            .resolve(
+                ClientKind::Codex,
+                MutationAction::Add,
+                Some(project_root.to_string_lossy().as_ref()),
+                Some("mcp::codex::project_shared::/tmp/workspace/.codex/config.toml::mcp_servers"),
+                Some(project_source.to_string_lossy().as_ref()),
+            )
+            .expect_err("unsupported scope should fail");
+
+        let _ = fs::remove_dir_all(&project_root);
+
+        assert!(error.message.contains("unsupported scope 'project_shared'"));
+        assert!(error.message.contains("Supported scopes: user"));
+    }
+
+    #[test]
+    fn resolve_builds_project_private_descriptor_from_explicit_target() {
+        let detector_registry = DetectorRegistry::with_default_detectors();
+        let resolver = McpMutationTargetResolver::new(&detector_registry);
+        let project_root = temp_project_root("target-project-private");
+        let claude_config = project_root.join("claude.json");
+        fs::write(&claude_config, "{}").expect("claude config should be writable");
+        let project_root_string = project_root.to_string_lossy().to_string();
+        let target_source_id = format!(
+            "mcp::claude_code::project_private::{}::/projects/{}/mcpServers",
+            claude_config.display(),
+            project_root_string.replace('~', "~0").replace('/', "~1"),
+        );
+
+        let descriptor = resolver
+            .resolve(
+                ClientKind::ClaudeCode,
+                MutationAction::Add,
+                Some(project_root_string.as_str()),
+                Some(target_source_id.as_str()),
+                Some(claude_config.to_string_lossy().as_ref()),
+            )
+            .expect("project-private descriptor should resolve from explicit target");
+
+        let _ = fs::remove_dir_all(&project_root);
+
+        assert_eq!(descriptor.source_scope, ResourceSourceScope::ProjectPrivate);
+        assert_eq!(descriptor.container_path, claude_config);
+        assert_eq!(
+            descriptor.selector,
+            format!(
+                "/projects/{}/mcpServers",
+                project_root_string.replace('~', "~0").replace('/', "~1")
+            )
+        );
+    }
+
+    fn temp_project_root(suffix: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "ai-manager-mcp-mutation-target-{}-{}",
+            std::process::id(),
+            suffix
+        ));
+        let _ = fs::create_dir_all(&root);
+        root
+    }
+}

--- a/src-tauri/src/application/mcp/source_catalog_service.rs
+++ b/src-tauri/src/application/mcp/source_catalog_service.rs
@@ -126,7 +126,7 @@ fn build_source_descriptors(
     descriptors
 }
 
-fn descriptor_for_scope(
+pub(super) fn descriptor_for_scope(
     client: ClientKind,
     source_scope: ResourceSourceScope,
     container_path: PathBuf,
@@ -160,7 +160,7 @@ fn descriptor_for_scope(
     }
 }
 
-fn selector_for_scope(
+pub(super) fn selector_for_scope(
     client: ClientKind,
     source_scope: ResourceSourceScope,
     project_root: Option<&str>,
@@ -182,7 +182,7 @@ fn selector_for_scope(
     }
 }
 
-fn storage_kind_for_client(client: ClientKind) -> McpSourceStorageKind {
+pub(super) fn storage_kind_for_client(client: ClientKind) -> McpSourceStorageKind {
     match client {
         ClientKind::Codex => McpSourceStorageKind::TomlTable,
         ClientKind::ClaudeCode | ClientKind::Cursor => McpSourceStorageKind::JsonSection,


### PR DESCRIPTION
## Summary
- resolve MCP mutation targets from source descriptors and explicit `target_source_id`
- write Claude and Cursor project destinations to the correct native sections or files
- return resolved target source metadata and cover project-aware mutation paths with tests

Closes #122