### PR TITLE
feat: add personal and project resource context shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
     "package:macos:dmg": "node ./scripts/package-macos-dmg.mjs",
-    "test": "pnpm run test:contracts",
+    "test": "pnpm run test:contracts && pnpm run test:web:unit",
     "test:contracts": "node --test tests/error-ui-contract.test.mjs tests/normalized-domain-model.test.mjs tests/support-matrix.test.mjs tests/mvp-acceptance-contract.test.mjs",
+    "test:web:unit": "tsx --test tests/resource-context.test.ts",
     "prepare": "husky"
   },
   "lint-staged": {
@@ -55,6 +56,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.3.2",
     "tailwindcss": "^4.2.1",
+    "tsx": "^4.21.0",
     "typescript": "~5.9.3",
     "vite": "^7.3.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
         version: 2.4.4
       '@tailwindcss/vite':
         specifier: ^4.2.1
-        version: 4.2.1(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
+        version: 4.2.1(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@tauri-apps/cli':
         specifier: ^2.10.0
         version: 2.10.0
@@ -53,7 +53,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.1.4
-        version: 5.1.4(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
+        version: 5.1.4(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -63,12 +63,15 @@ importers:
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.1
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+        version: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -896,6 +899,9 @@ packages:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
 
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1073,6 +1079,9 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
@@ -1145,6 +1154,11 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1624,12 +1638,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
 
-  '@tailwindcss/vite@4.2.1(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.2.1(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@tauri-apps/api@2.10.1': {}
 
@@ -1715,7 +1729,7 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@5.1.4(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
+  '@vitejs/plugin-react@5.1.4(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -1723,7 +1737,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -1838,6 +1852,10 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-east-asian-width@1.5.0: {}
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   graceful-fs@4.2.11: {}
 
@@ -1978,6 +1996,8 @@ snapshots:
 
   react@19.2.4: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
@@ -2068,6 +2088,13 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
   typescript@5.9.3: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
@@ -2076,7 +2103,7 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2):
+  vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2088,6 +2115,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.31.1
+      tsx: 4.21.0
       yaml: 2.8.2
 
   wrap-ansi@9.0.2:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,12 @@ import { formatClientLabel } from "./features/clients/client-labels";
 import { useClientDetections } from "./features/clients/useClientDetections";
 import { McpManagerPanel } from "./features/mcp/McpManagerPanel";
 import { type AppRoute, NAVIGATION_ITEMS } from "./features/navigation";
+import { ResourceContextBar } from "./features/resources/ResourceContextBar";
+import {
+  normalizeProjectRootInput,
+  type ResourceContextMode,
+  type ResourceContextState,
+} from "./features/resources/resource-context";
 import { SkillsManagerPanel } from "./features/skills/SkillsManagerPanel";
 import { cn } from "./lib/utils";
 import "./App.css";
@@ -24,20 +30,39 @@ function findSelectedDetection(
   return detections.find((entry) => entry.client === selectedClient) ?? null;
 }
 
-function renderRouteContent(route: AppRoute, selectedDetection: ClientDetection | null) {
+function renderRouteContent(
+  route: AppRoute,
+  selectedDetection: ClientDetection | null,
+  resourceContext: ResourceContextState,
+) {
   if (route === "dashboard") {
     return null;
   }
 
   if (route === "mcp") {
-    return <McpManagerPanel client={selectedDetection?.client ?? null} />;
+    return (
+      <McpManagerPanel
+        client={selectedDetection?.client ?? null}
+        contextMode={resourceContext.mode}
+        projectRoot={resourceContext.projectRoot}
+      />
+    );
   }
 
-  return <SkillsManagerPanel client={selectedDetection?.client ?? null} />;
+  return (
+    <SkillsManagerPanel
+      client={selectedDetection?.client ?? null}
+      contextMode={resourceContext.mode}
+      projectRoot={resourceContext.projectRoot}
+    />
+  );
 }
 
 function App() {
   const [activeRoute, setActiveRoute] = useState<AppRoute>("dashboard");
+  const [resourceContextMode, setResourceContextMode] = useState<ResourceContextMode>("personal");
+  const [draftProjectRoot, setDraftProjectRoot] = useState("");
+  const [projectRoot, setProjectRoot] = useState<string | null>(null);
   const {
     phase,
     detections,
@@ -53,10 +78,17 @@ function App() {
     () => findSelectedDetection(detections, selectedClient),
     [detections, selectedClient],
   );
+  const resourceContext = useMemo<ResourceContextState>(
+    () => ({
+      mode: resourceContextMode,
+      projectRoot: resourceContextMode === "project" ? projectRoot : null,
+    }),
+    [projectRoot, resourceContextMode],
+  );
 
   const featureContent = useMemo(
-    () => renderRouteContent(activeRoute, selectedDetection),
-    [activeRoute, selectedDetection],
+    () => renderRouteContent(activeRoute, selectedDetection, resourceContext),
+    [activeRoute, resourceContext, selectedDetection],
   );
   const isDashboardRoute = activeRoute === "dashboard";
 
@@ -223,6 +255,23 @@ function App() {
                 </div>
               </section>
             )}
+
+            {!isDashboardRoute ? (
+              <ResourceContextBar
+                mode={resourceContextMode}
+                draftProjectRoot={draftProjectRoot}
+                projectRoot={projectRoot}
+                onModeChange={setResourceContextMode}
+                onDraftProjectRootChange={setDraftProjectRoot}
+                onApplyProjectRoot={() =>
+                  setProjectRoot(normalizeProjectRootInput(draftProjectRoot))
+                }
+                onClearProjectRoot={() => {
+                  setDraftProjectRoot("");
+                  setProjectRoot(null);
+                }}
+              />
+            ) : null}
 
             {featureContent}
           </>

--- a/src/features/mcp/McpManagerPanel.tsx
+++ b/src/features/mcp/McpManagerPanel.tsx
@@ -12,6 +12,11 @@ import { Button } from "../../components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { Input } from "../../components/ui/input";
 import { formatClientLabel } from "../clients/client-labels";
+import {
+  buildResourceContextSummary,
+  isProjectContextIncomplete,
+  type ResourceContextMode,
+} from "../resources/resource-context";
 import { McpAddForm } from "./McpAddForm";
 import { McpCopyForm } from "./McpCopyForm";
 import { McpEditForm } from "./McpEditForm";
@@ -24,14 +29,23 @@ import { useMcpManager } from "./useMcpManager";
 
 interface McpManagerPanelProps {
   client: ClientKind | null;
+  contextMode: ResourceContextMode;
+  projectRoot: string | null;
 }
 
-export function McpManagerPanel({ client }: McpManagerPanelProps) {
+export function McpManagerPanel({ client, contextMode, projectRoot }: McpManagerPanelProps) {
   const [isComposerOpen, setComposerOpen] = useState(false);
   const [isCopyOpen, setCopyOpen] = useState(false);
   const [isEditOpen, setEditOpen] = useState(false);
   const [removalCandidate, setRemovalCandidate] = useState<ResourceRecord | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const contextSummary = buildResourceContextSummary({
+    mode: contextMode,
+    projectRoot,
+  });
+  const activeClient = isProjectContextIncomplete({ mode: contextMode, projectRoot })
+    ? null
+    : client;
 
   const {
     phase,
@@ -48,7 +62,7 @@ export function McpManagerPanel({ client }: McpManagerPanelProps) {
     removeMcp,
     refresh,
     clearFeedback,
-  } = useMcpManager(client);
+  } = useMcpManager(activeClient);
 
   const existingTargetIds = useMemo(() => {
     const ids = new Set<string>();
@@ -166,6 +180,15 @@ export function McpManagerPanel({ client }: McpManagerPanelProps) {
     );
   }
 
+  if (contextMode === "project" && projectRoot === null) {
+    return (
+      <ViewStatePanel
+        title="Project Context Required"
+        message="Apply a project root to prepare project-aware MCP screens."
+      />
+    );
+  }
+
   return (
     <>
       <Card className="overflow-hidden border-slate-200 bg-[linear-gradient(180deg,#f8fbff_0%,#ffffff_38%)] shadow-[0_18px_36px_rgba(30,41,59,0.08)]">
@@ -176,6 +199,7 @@ export function McpManagerPanel({ client }: McpManagerPanelProps) {
               <p className="mt-1 text-sm text-slate-700">
                 Managing <strong>{formatClientLabel(client)}</strong>
               </p>
+              <p className="mt-1 text-xs text-slate-500">{contextSummary.description}</p>
             </div>
             <div className="flex items-center gap-2">
               <Button

--- a/src/features/resources/ResourceContextBar.tsx
+++ b/src/features/resources/ResourceContextBar.tsx
@@ -1,0 +1,110 @@
+import { Button } from "../../components/ui/button";
+import { Input } from "../../components/ui/input";
+import { cn } from "../../lib/utils";
+
+import {
+  buildResourceContextSummary,
+  normalizeProjectRootInput,
+  type ResourceContextMode,
+} from "./resource-context";
+
+interface ResourceContextBarProps {
+  mode: ResourceContextMode;
+  draftProjectRoot: string;
+  projectRoot: string | null;
+  onModeChange: (mode: ResourceContextMode) => void;
+  onDraftProjectRootChange: (value: string) => void;
+  onApplyProjectRoot: () => void;
+  onClearProjectRoot: () => void;
+}
+
+const MODES: ResourceContextMode[] = ["personal", "project"];
+
+export function ResourceContextBar({
+  mode,
+  draftProjectRoot,
+  projectRoot,
+  onModeChange,
+  onDraftProjectRootChange,
+  onApplyProjectRoot,
+  onClearProjectRoot,
+}: ResourceContextBarProps) {
+  const summary = buildResourceContextSummary({ mode, projectRoot });
+  const normalizedDraftProjectRoot = normalizeProjectRootInput(draftProjectRoot);
+  const canApplyProjectRoot =
+    mode === "project" &&
+    normalizedDraftProjectRoot !== null &&
+    normalizedDraftProjectRoot !== projectRoot;
+
+  return (
+    <section className="grid gap-3 rounded-2xl border border-slate-200 bg-[linear-gradient(180deg,#fbfdff_0%,#f7fafc_100%)] px-4 py-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="grid gap-1">
+          <p className="text-[0.7rem] font-semibold uppercase tracking-[0.09em] text-slate-500">
+            Resource Context
+          </p>
+          <h3 className="text-sm font-semibold text-slate-900">{summary.title}</h3>
+          <p className="text-sm text-slate-700">{summary.description}</p>
+        </div>
+
+        <div
+          className="inline-flex rounded-xl border border-slate-200 bg-white p-1"
+          role="tablist"
+          aria-label="Resource Context Mode"
+        >
+          {MODES.map((candidateMode) => (
+            <button
+              key={candidateMode}
+              type="button"
+              role="tab"
+              aria-selected={mode === candidateMode}
+              className={cn(
+                "rounded-lg px-3 py-1.5 text-sm font-medium transition",
+                mode === candidateMode
+                  ? "bg-slate-900 text-white shadow-sm"
+                  : "text-slate-600 hover:bg-slate-100 hover:text-slate-900",
+              )}
+              onClick={() => onModeChange(candidateMode)}
+            >
+              {candidateMode === "personal" ? "Personal" : "Project"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {mode === "project" ? (
+        <div className="grid gap-2">
+          <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
+            <Input
+              value={draftProjectRoot}
+              onChange={(event) => onDraftProjectRootChange(event.currentTarget.value)}
+              placeholder="/Users/fengliu/Code/ai-manager"
+              aria-label="Project root"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onApplyProjectRoot}
+              disabled={!canApplyProjectRoot}
+            >
+              Apply Project
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClearProjectRoot}
+              disabled={draftProjectRoot.length === 0 && projectRoot === null}
+            >
+              Clear
+            </Button>
+          </div>
+
+          <p className="text-xs text-slate-500">
+            Project mode keeps the current client workflow for now, while preparing project-aware
+            resource views and destination selection.
+          </p>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/resources/resource-context.ts
+++ b/src/features/resources/resource-context.ts
@@ -1,0 +1,42 @@
+export type ResourceContextMode = "personal" | "project";
+
+export interface ResourceContextState {
+  mode: ResourceContextMode;
+  projectRoot: string | null;
+}
+
+export interface ResourceContextSummary {
+  title: string;
+  description: string;
+}
+
+export function normalizeProjectRootInput(value: string): string | null {
+  const normalized = value.trim();
+  return normalized.length === 0 ? null : normalized;
+}
+
+export function isProjectContextIncomplete(context: ResourceContextState): boolean {
+  return context.mode === "project" && context.projectRoot === null;
+}
+
+export function buildResourceContextSummary(context: ResourceContextState): ResourceContextSummary {
+  if (context.mode === "personal") {
+    return {
+      title: "Personal context",
+      description: "Manage personal resources without binding the current view to a project root.",
+    };
+  }
+
+  if (context.projectRoot === null) {
+    return {
+      title: "Project context",
+      description:
+        "Apply a project root to prepare project-aware resource views and destination choices.",
+    };
+  }
+
+  return {
+    title: "Project context",
+    description: `Project root applied: ${context.projectRoot}`,
+  };
+}

--- a/src/features/skills/SkillsManagerPanel.tsx
+++ b/src/features/skills/SkillsManagerPanel.tsx
@@ -11,6 +11,11 @@ import { Button } from "../../components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { Input } from "../../components/ui/input";
 import { formatClientLabel } from "../clients/client-labels";
+import {
+  buildResourceContextSummary,
+  isProjectContextIncomplete,
+  type ResourceContextMode,
+} from "../resources/resource-context";
 import { SkillAddForm } from "./SkillAddForm";
 import { SkillCopyForm } from "./SkillCopyForm";
 import { SkillEditForm } from "./SkillEditForm";
@@ -24,14 +29,23 @@ import { useSkillManager } from "./useSkillManager";
 
 interface SkillsManagerPanelProps {
   client: ClientKind | null;
+  contextMode: ResourceContextMode;
+  projectRoot: string | null;
 }
 
-export function SkillsManagerPanel({ client }: SkillsManagerPanelProps) {
+export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsManagerPanelProps) {
   const [isComposerOpen, setComposerOpen] = useState(false);
   const [isCopyOpen, setCopyOpen] = useState(false);
   const [isEditOpen, setEditOpen] = useState(false);
   const [removalCandidate, setRemovalCandidate] = useState<ResourceRecord | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const contextSummary = buildResourceContextSummary({
+    mode: contextMode,
+    projectRoot,
+  });
+  const activeClient = isProjectContextIncomplete({ mode: contextMode, projectRoot })
+    ? null
+    : client;
 
   const {
     phase,
@@ -49,7 +63,7 @@ export function SkillsManagerPanel({ client }: SkillsManagerPanelProps) {
     removeSkill,
     refresh,
     clearFeedback,
-  } = useSkillManager(client);
+  } = useSkillManager(activeClient);
 
   const existingSkillsById = useMemo(() => {
     const entries = new Map<
@@ -173,6 +187,15 @@ export function SkillsManagerPanel({ client }: SkillsManagerPanelProps) {
     );
   }
 
+  if (contextMode === "project" && projectRoot === null) {
+    return (
+      <ViewStatePanel
+        title="Project Context Required"
+        message="Apply a project root to prepare project-aware Skills screens."
+      />
+    );
+  }
+
   return (
     <>
       <Card className="overflow-hidden border-slate-200 bg-[linear-gradient(180deg,#fafbff_0%,#ffffff_38%)] shadow-[0_18px_36px_rgba(30,41,59,0.08)]">
@@ -183,6 +206,7 @@ export function SkillsManagerPanel({ client }: SkillsManagerPanelProps) {
               <p className="mt-1 text-sm text-slate-700">
                 Managing <strong>{formatClientLabel(client)}</strong>
               </p>
+              <p className="mt-1 text-xs text-slate-500">{contextSummary.description}</p>
             </div>
             <div className="flex items-center gap-2">
               <Button

--- a/tests/resource-context.test.ts
+++ b/tests/resource-context.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildResourceContextSummary,
+  isProjectContextIncomplete,
+  normalizeProjectRootInput,
+} from "../src/features/resources/resource-context.ts";
+
+test("normalizeProjectRootInput trims whitespace and collapses empty values", () => {
+  assert.equal(normalizeProjectRootInput("  /Users/demo/project  "), "/Users/demo/project");
+  assert.equal(normalizeProjectRootInput("   "), null);
+});
+
+test("project context is incomplete only when project mode lacks a root", () => {
+  assert.equal(
+    isProjectContextIncomplete({
+      mode: "project",
+      projectRoot: null,
+    }),
+    true,
+  );
+  assert.equal(
+    isProjectContextIncomplete({
+      mode: "project",
+      projectRoot: "/Users/demo/project",
+    }),
+    false,
+  );
+  assert.equal(
+    isProjectContextIncomplete({
+      mode: "personal",
+      projectRoot: null,
+    }),
+    false,
+  );
+});
+
+test("buildResourceContextSummary returns stable user-facing copy", () => {
+  assert.deepEqual(
+    buildResourceContextSummary({
+      mode: "personal",
+      projectRoot: null,
+    }),
+    {
+      title: "Personal context",
+      description: "Manage personal resources without binding the current view to a project root.",
+    },
+  );
+
+  assert.deepEqual(
+    buildResourceContextSummary({
+      mode: "project",
+      projectRoot: null,
+    }),
+    {
+      title: "Project context",
+      description:
+        "Apply a project root to prepare project-aware resource views and destination choices.",
+    },
+  );
+
+  assert.deepEqual(
+    buildResourceContextSummary({
+      mode: "project",
+      projectRoot: "/Users/demo/project",
+    }),
+    {
+      title: "Project context",
+      description: "Project root applied: /Users/demo/project",
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add a shared personal/project resource context shell to the app layout
- gate MCP and Skills manager screens when project mode is selected without a project root
- cover the new resource context helpers with lightweight frontend unit tests

## Testing
- pnpm run ci:web
- pnpm run lint
- pnpm test
- pnpm outdated

Closes #126