### PR TITLE
feat: make MCP manager context-first and source-aware

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "package:macos:dmg": "node ./scripts/package-macos-dmg.mjs",
     "test": "pnpm run test:contracts && pnpm run test:web:unit",
     "test:contracts": "node --test tests/error-ui-contract.test.mjs tests/normalized-domain-model.test.mjs tests/support-matrix.test.mjs tests/mvp-acceptance-contract.test.mjs",
-    "test:web:unit": "tsx --test tests/resource-context.test.ts",
+    "test:web:unit": "tsx --test tests/resource-context.test.ts tests/mcp-targets.test.ts",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,6 @@ function renderRouteContent(
   if (route === "mcp") {
     return (
       <McpManagerPanel
-        client={selectedDetection?.client ?? null}
         contextMode={resourceContext.mode}
         projectRoot={resourceContext.projectRoot}
       />
@@ -218,7 +217,7 @@ function App() {
                   />
                 ))}
               </section>
-            ) : (
+            ) : activeRoute === "skills" ? (
               <section className="flex flex-wrap items-end justify-between gap-3 rounded-2xl border border-slate-200 bg-[linear-gradient(180deg,#fbfdff_0%,#f7fafc_100%)] px-4 py-3">
                 <div className="grid gap-1">
                   <p className="text-[0.7rem] font-semibold uppercase tracking-[0.09em] text-slate-500">
@@ -253,6 +252,26 @@ function App() {
                     Open Dashboard
                   </Button>
                 </div>
+              </section>
+            ) : (
+              <section className="flex flex-wrap items-end justify-between gap-3 rounded-2xl border border-slate-200 bg-[linear-gradient(180deg,#fbfdff_0%,#f7fafc_100%)] px-4 py-3">
+                <div className="grid gap-1">
+                  <p className="text-[0.7rem] font-semibold uppercase tracking-[0.09em] text-slate-500">
+                    MCP Overview
+                  </p>
+                  <p className="text-sm text-slate-700">
+                    MCP resources now span all supported clients inside the selected context.
+                  </p>
+                </div>
+
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setActiveRoute("dashboard")}
+                >
+                  Open Dashboard
+                </Button>
               </section>
             )}
 

--- a/src/features/mcp/McpAddForm.tsx
+++ b/src/features/mcp/McpAddForm.tsx
@@ -1,19 +1,28 @@
 import { type FormEvent, type KeyboardEvent, useRef } from "react";
 
+import type { ClientKind } from "../../backend/contracts";
 import { Alert } from "../../components/ui/alert";
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { cn } from "../../lib/utils";
+import { formatClientLabel } from "../clients/client-labels";
 import { buildPresetTransportChecksum } from "./mcp-checksum";
+import { MCP_CLIENTS } from "./mcp-targets";
 import type { McpOfficialPreset } from "./official-presets";
 import type { McpAddFormState, McpAddMode, McpPresetSource, TransportMode } from "./useMcpAddForm";
 
 interface McpAddFormProps {
   disabled: boolean;
   state: McpAddFormState;
+  destinationClient: ClientKind;
+  destinationLabel: string;
+  destinationDescription: string;
+  destinationNotice: string | null;
+  submitLabel: string;
   existingTargetIds: ReadonlySet<string>;
   existingTransportChecksums: ReadonlySet<string>;
+  onDestinationClientChange: (value: ClientKind) => void;
   onModeChange: (value: McpAddMode) => void;
   onTargetIdChange: (value: string) => void;
   onTransportModeChange: (value: TransportMode) => void;
@@ -32,8 +41,14 @@ interface McpAddFormProps {
 export function McpAddForm({
   disabled,
   state,
+  destinationClient,
+  destinationLabel,
+  destinationDescription,
+  destinationNotice,
+  submitLabel,
   existingTargetIds,
   existingTransportChecksums,
+  onDestinationClientChange,
   onModeChange,
   onTargetIdChange,
   onTransportModeChange,
@@ -256,6 +271,25 @@ export function McpAddForm({
       onSubmit={(event) => void onSubmit(event)}
     >
       {state.localError ? <Alert variant="destructive">{state.localError}</Alert> : null}
+      <Label htmlFor="mcp-destination-client">Destination Client</Label>
+      <select
+        id="mcp-destination-client"
+        className="h-10 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 disabled:cursor-not-allowed disabled:opacity-50"
+        value={destinationClient}
+        onChange={(event) => onDestinationClientChange(event.currentTarget.value as ClientKind)}
+        disabled={disabled}
+      >
+        {MCP_CLIENTS.map((client) => (
+          <option key={client} value={client}>
+            {formatClientLabel(client)}
+          </option>
+        ))}
+      </select>
+
+      <Alert variant="default">
+        <strong>{destinationLabel}.</strong> {destinationDescription}
+      </Alert>
+      {destinationNotice ? <Alert variant="warning">{destinationNotice}</Alert> : null}
 
       <Label>Add Method</Label>
       <div className="grid grid-cols-3 gap-2 max-[560px]:grid-cols-1">
@@ -398,11 +432,7 @@ export function McpAddForm({
       </label>
 
       <Button type="submit" disabled={disabled}>
-        {state.mode === "manual"
-          ? "Add MCP"
-          : state.mode === "registry"
-            ? "Add from Registry"
-            : "Add from Preset"}
+        {submitLabel}
       </Button>
     </form>
   );

--- a/src/features/mcp/McpCopyForm.tsx
+++ b/src/features/mcp/McpCopyForm.tsx
@@ -7,11 +7,14 @@ import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { cn } from "../../lib/utils";
 import { formatClientLabel } from "../clients/client-labels";
+import type { McpMutationTargetPlan } from "./mcp-targets";
+import { describeMcpAction, MCP_CLIENTS } from "./mcp-targets";
 import type { McpCopyFormState } from "./useMcpCopyForm";
 
 interface McpCopyFormProps {
   disabled: boolean;
   state: McpCopyFormState;
+  destinationPlan: McpMutationTargetPlan;
   onDestinationClientChange: (value: ClientKind) => void;
   onTargetIdChange: (value: string) => void;
   onEnabledChange: (value: boolean) => void;
@@ -19,18 +22,17 @@ interface McpCopyFormProps {
   className?: string;
 }
 
-const CLIENTS: ClientKind[] = ["codex", "claude_code", "cursor"];
-
 export function McpCopyForm({
   disabled,
   state,
+  destinationPlan,
   onDestinationClientChange,
   onTargetIdChange,
   onEnabledChange,
   onSubmit,
   className,
 }: McpCopyFormProps) {
-  const destinationOptions = CLIENTS.filter((client) => client !== state.sourceClient);
+  const destinationOptions = MCP_CLIENTS.filter((client) => client !== state.sourceClient);
 
   return (
     <form
@@ -44,6 +46,13 @@ export function McpCopyForm({
         specific extras (for example `env`, headers, or optional transport metadata) are not copied
         in this version.
       </Alert>
+      <Alert variant="default">
+        <strong>{destinationPlan.destinationLabel}.</strong>{" "}
+        {destinationPlan.destinationDescription}
+      </Alert>
+      {destinationPlan.fallbackNotice ? (
+        <Alert variant="warning">{destinationPlan.fallbackNotice}</Alert>
+      ) : null}
 
       <Label>Source</Label>
       <p className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">
@@ -95,7 +104,7 @@ export function McpCopyForm({
       </label>
 
       <Button type="submit" disabled={disabled || destinationOptions.length === 0}>
-        Copy MCP
+        {describeMcpAction("copy", destinationPlan)}
       </Button>
     </form>
   );

--- a/src/features/mcp/McpEditForm.tsx
+++ b/src/features/mcp/McpEditForm.tsx
@@ -37,6 +37,9 @@ export function McpEditForm({
       onSubmit={(event) => void onSubmit(event)}
     >
       {state.localError ? <Alert variant="destructive">{state.localError}</Alert> : null}
+      {state.sourceLabel ? (
+        <Alert variant="default">Editing the entry stored in {state.sourceLabel}.</Alert>
+      ) : null}
 
       {state.transportMode === "stdio" && state.command.trim().length === 0 ? (
         <Alert variant="warning">
@@ -113,7 +116,7 @@ export function McpEditForm({
       </label>
 
       <Button type="submit" disabled={disabled}>
-        Update MCP
+        Update in {state.sourceLabel || "selected source"}
       </Button>
     </form>
   );

--- a/src/features/mcp/McpManagerPanel.tsx
+++ b/src/features/mcp/McpManagerPanel.tsx
@@ -1,7 +1,7 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
-import type { ClientKind, ResourceRecord } from "../../backend/contracts";
+import type { ClientKind, ResourceRecord, ResourceViewMode } from "../../backend/contracts";
 import { ConfirmModal } from "../../components/shared/ConfirmModal";
 import { ErrorRecoveryCallout } from "../../components/shared/ErrorRecoveryCallout";
 import { SlideOverPanel } from "../../components/shared/SlideOverPanel";
@@ -14,7 +14,6 @@ import { Input } from "../../components/ui/input";
 import { formatClientLabel } from "../clients/client-labels";
 import {
   buildResourceContextSummary,
-  isProjectContextIncomplete,
   type ResourceContextMode,
 } from "../resources/resource-context";
 import { McpAddForm } from "./McpAddForm";
@@ -22,34 +21,77 @@ import { McpCopyForm } from "./McpCopyForm";
 import { McpEditForm } from "./McpEditForm";
 import { McpResourceTable } from "./McpResourceTable";
 import { buildResourceTransportChecksum } from "./mcp-checksum";
+import {
+  buildMcpMutationTargetPlan,
+  buildMcpProjectModeHint,
+  describeMcpAction,
+  formatResourceViewModeLabel,
+  MCP_CLIENTS,
+  matchesMcpDestination,
+} from "./mcp-targets";
 import { useMcpAddForm } from "./useMcpAddForm";
 import { useMcpCopyForm } from "./useMcpCopyForm";
 import { useMcpEditForm } from "./useMcpEditForm";
 import { useMcpManager } from "./useMcpManager";
 
 interface McpManagerPanelProps {
-  client: ClientKind | null;
   contextMode: ResourceContextMode;
   projectRoot: string | null;
 }
 
-export function McpManagerPanel({ client, contextMode, projectRoot }: McpManagerPanelProps) {
+function toggleClientFilter(current: ClientKind[], client: ClientKind): ClientKind[] {
+  if (current.includes(client)) {
+    return current.length === 1 ? current : current.filter((entry) => entry !== client);
+  }
+
+  return [...current, client];
+}
+
+function includesSearchQuery(
+  resource: ResourceRecord,
+  normalizedQuery: string,
+  shadowingSource: ResourceRecord | null,
+): boolean {
+  if (normalizedQuery.length === 0) {
+    return true;
+  }
+
+  const haystack = [
+    formatClientLabel(resource.client),
+    resource.display_name,
+    resource.logical_id,
+    resource.transport_kind,
+    resource.transport_command,
+    resource.transport_url,
+    resource.source_label,
+    resource.source_scope,
+    resource.source_path,
+    shadowingSource?.source_label,
+  ]
+    .filter((value): value is string => value !== null && value !== undefined)
+    .join(" ")
+    .toLowerCase();
+
+  return haystack.includes(normalizedQuery);
+}
+
+export function McpManagerPanel({ contextMode, projectRoot }: McpManagerPanelProps) {
   const [isComposerOpen, setComposerOpen] = useState(false);
   const [isCopyOpen, setCopyOpen] = useState(false);
   const [isEditOpen, setEditOpen] = useState(false);
   const [removalCandidate, setRemovalCandidate] = useState<ResourceRecord | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const [viewMode, setViewMode] = useState<ResourceViewMode>("effective");
+  const [clientFilters, setClientFilters] = useState<ClientKind[]>(MCP_CLIENTS);
   const contextSummary = buildResourceContextSummary({
     mode: contextMode,
     projectRoot,
   });
-  const activeClient = isProjectContextIncomplete({ mode: contextMode, projectRoot })
-    ? null
-    : client;
 
   const {
     phase,
     resources,
+    resolvedProjectRoot,
     warning,
     operationError,
     feedback,
@@ -62,31 +104,22 @@ export function McpManagerPanel({ client, contextMode, projectRoot }: McpManager
     removeMcp,
     refresh,
     clearFeedback,
-  } = useMcpManager(activeClient);
+  } = useMcpManager({
+    contextMode,
+    projectRoot,
+    viewMode,
+  });
 
-  const existingTargetIds = useMemo(() => {
-    const ids = new Set<string>();
-    for (const resource of resources) {
-      ids.add(resource.display_name.trim().toLowerCase());
-    }
-    return ids;
-  }, [resources]);
-  const existingTransportChecksums = useMemo(() => {
-    const checksums = new Set<string>();
-    for (const resource of resources) {
-      const checksum = buildResourceTransportChecksum(resource);
-      if (checksum) {
-        checksums.add(checksum);
-      }
-    }
-    return checksums;
-  }, [resources]);
+  const effectiveProjectRoot = resolvedProjectRoot ?? projectRoot;
+  const resolveDestination = useCallback(
+    (client: ClientKind) => buildMcpMutationTargetPlan(client, contextMode, effectiveProjectRoot),
+    [contextMode, effectiveProjectRoot],
+  );
 
   const addForm = useMcpAddForm({
     onSubmit: addMcp,
+    resolveDestination,
     onAccepted: () => setComposerOpen(false),
-    existingTargetIds,
-    existingTransportChecksums,
   });
   const editForm = useMcpEditForm({
     onSubmit: updateMcp,
@@ -94,10 +127,67 @@ export function McpManagerPanel({ client, contextMode, projectRoot }: McpManager
   });
   const copyForm = useMcpCopyForm({
     onSubmit: copyMcp,
+    resolveDestination,
     onAccepted: () => setCopyOpen(false),
   });
 
+  const addDestinationPlan = useMemo(
+    () => resolveDestination(addForm.state.destinationClient),
+    [addForm.state.destinationClient, resolveDestination],
+  );
+  const copyDestinationPlan = useMemo(
+    () => resolveDestination(copyForm.state.destinationClient),
+    [copyForm.state.destinationClient, resolveDestination],
+  );
+
   const normalizedQuery = searchQuery.trim().toLowerCase();
+  const resourcesById = useMemo(
+    () => new Map(resources.map((resource) => [resource.id, resource])),
+    [resources],
+  );
+  const clientCounts = useMemo(() => {
+    const counts = new Map<ClientKind, number>(MCP_CLIENTS.map((client) => [client, 0]));
+    for (const resource of resources) {
+      counts.set(resource.client, (counts.get(resource.client) ?? 0) + 1);
+    }
+    return counts;
+  }, [resources]);
+  const addDestinationResources = useMemo(
+    () => resources.filter((resource) => matchesMcpDestination(resource, addDestinationPlan)),
+    [addDestinationPlan, resources],
+  );
+  const existingTargetIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const resource of addDestinationResources) {
+      ids.add(resource.display_name.trim().toLowerCase());
+    }
+    return ids;
+  }, [addDestinationResources]);
+  const existingTransportChecksums = useMemo(() => {
+    const checksums = new Set<string>();
+    for (const resource of addDestinationResources) {
+      const checksum = buildResourceTransportChecksum(resource);
+      if (checksum) {
+        checksums.add(checksum);
+      }
+    }
+    return checksums;
+  }, [addDestinationResources]);
+  const filteredResources = useMemo(
+    () =>
+      resources.filter((resource) => {
+        if (!clientFilters.includes(resource.client)) {
+          return false;
+        }
+
+        return includesSearchQuery(
+          resource,
+          normalizedQuery,
+          resource.shadowed_by ? (resourcesById.get(resource.shadowed_by) ?? null) : null,
+        );
+      }),
+    [clientFilters, normalizedQuery, resources, resourcesById],
+  );
   const snackbarFeedback = useMemo(() => {
     if (feedback === null) {
       return null;
@@ -113,25 +203,6 @@ export function McpManagerPanel({ client, contextMode, projectRoot }: McpManager
       message: feedback.message,
     };
   }, [feedback]);
-  const filteredResources = useMemo(() => {
-    if (normalizedQuery.length === 0) {
-      return resources;
-    }
-
-    return resources.filter((resource) => {
-      const haystack = [
-        resource.display_name,
-        resource.transport_kind,
-        resource.source_path,
-        resource.id,
-      ]
-        .filter((value): value is string => value !== null && value !== undefined)
-        .join(" ")
-        .toLowerCase();
-
-      return haystack.includes(normalizedQuery);
-    });
-  }, [normalizedQuery, resources]);
 
   async function handleRemove(resource: ResourceRecord) {
     setRemovalCandidate(resource);
@@ -139,7 +210,7 @@ export function McpManagerPanel({ client, contextMode, projectRoot }: McpManager
 
   async function handleEdit(resource: ResourceRecord) {
     clearFeedback();
-    editForm.loadResource(resource);
+    editForm.loadResource(resource, effectiveProjectRoot);
     setEditOpen(true);
   }
 
@@ -154,7 +225,14 @@ export function McpManagerPanel({ client, contextMode, projectRoot }: McpManager
       return;
     }
 
-    await removeMcp(removalCandidate.display_name, removalCandidate.source_path);
+    await removeMcp({
+      resourceId: removalCandidate.id,
+      client: removalCandidate.client,
+      targetId: removalCandidate.display_name,
+      projectRoot: effectiveProjectRoot,
+      targetSourceId: removalCandidate.source_id,
+      sourceLabel: removalCandidate.source_label,
+    });
     setRemovalCandidate(null);
   }
 
@@ -168,16 +246,10 @@ export function McpManagerPanel({ client, contextMode, projectRoot }: McpManager
 
   function openComposer() {
     clearFeedback();
+    if (clientFilters.length === 1) {
+      addForm.setDestinationClient(clientFilters[0]);
+    }
     setComposerOpen(true);
-  }
-
-  if (client === null) {
-    return (
-      <ViewStatePanel
-        title="Client Selection Required"
-        message="Select a client to list and mutate MCP entries."
-      />
-    );
   }
 
   if (contextMode === "project" && projectRoot === null) {
@@ -196,10 +268,11 @@ export function McpManagerPanel({ client, contextMode, projectRoot }: McpManager
           <div className="flex items-start justify-between gap-3 max-[720px]:flex-col">
             <div>
               <CardTitle className="text-[1.35rem] tracking-[-0.012em]">MCP Manager</CardTitle>
-              <p className="mt-1 text-sm text-slate-700">
-                Managing <strong>{formatClientLabel(client)}</strong>
+              <p className="mt-1 text-sm text-slate-700">{contextSummary.description}</p>
+              <p className="mt-1 text-xs text-slate-500">
+                {formatResourceViewModeLabel(viewMode)} across {clientFilters.length} client filter
+                {clientFilters.length === 1 ? "" : "s"}.
               </p>
-              <p className="mt-1 text-xs text-slate-500">{contextSummary.description}</p>
             </div>
             <div className="flex items-center gap-2">
               <Button
@@ -215,26 +288,75 @@ export function McpManagerPanel({ client, contextMode, projectRoot }: McpManager
                 {phase === "loading" ? "Loading..." : "Reload"}
               </Button>
               <Button type="button" size="sm" onClick={openComposer}>
-                Add MCP
+                Add MCP Destination
               </Button>
             </div>
           </div>
 
-          <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-slate-200/90 bg-white/90 p-2.5">
-            <p className="rounded-full bg-slate-900 px-3 py-1 text-[0.69rem] font-semibold uppercase tracking-[0.08em] text-slate-100">
-              {resources.length} entries
-            </p>
-            <Input
-              value={searchQuery}
-              onChange={(event) => setSearchQuery(event.currentTarget.value)}
-              className="h-9 max-w-[19rem] border-slate-200 bg-white max-[720px]:max-w-full"
-              placeholder="Search name, transport, source path"
-            />
-            {normalizedQuery.length > 0 ? (
-              <Button type="button" variant="ghost" size="sm" onClick={() => setSearchQuery("")}>
-                Clear
+          {contextMode === "project" ? (
+            <Alert variant="default">{buildMcpProjectModeHint()}</Alert>
+          ) : null}
+
+          <div className="grid gap-3 rounded-2xl border border-slate-200/90 bg-white/90 p-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="rounded-full bg-slate-900 px-3 py-1 text-[0.69rem] font-semibold uppercase tracking-[0.08em] text-slate-100">
+                {filteredResources.length} shown / {resources.length} total
+              </p>
+              <div className="inline-flex rounded-xl border border-slate-200 bg-slate-50 p-1">
+                {(["effective", "all_sources"] as ResourceViewMode[]).map((candidateMode) => (
+                  <button
+                    key={candidateMode}
+                    type="button"
+                    className={
+                      viewMode === candidateMode
+                        ? "rounded-lg bg-slate-900 px-3 py-1.5 text-sm font-medium text-white shadow-sm"
+                        : "rounded-lg px-3 py-1.5 text-sm font-medium text-slate-600 hover:bg-white hover:text-slate-900"
+                    }
+                    onClick={() => setViewMode(candidateMode)}
+                  >
+                    {formatResourceViewModeLabel(candidateMode)}
+                  </button>
+                ))}
+              </div>
+              <Input
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.currentTarget.value)}
+                className="h-9 max-w-[19rem] border-slate-200 bg-white max-[720px]:max-w-full"
+                placeholder="Search name, transport, source label"
+              />
+              {normalizedQuery.length > 0 ? (
+                <Button type="button" variant="ghost" size="sm" onClick={() => setSearchQuery("")}>
+                  Clear
+                </Button>
+              ) : null}
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant={clientFilters.length === MCP_CLIENTS.length ? "default" : "outline"}
+                size="sm"
+                onClick={() => setClientFilters(MCP_CLIENTS)}
+              >
+                All Clients
               </Button>
-            ) : null}
+              {MCP_CLIENTS.map((client) => {
+                const active = clientFilters.includes(client);
+                return (
+                  <Button
+                    key={client}
+                    type="button"
+                    variant={active ? "secondary" : "outline"}
+                    size="sm"
+                    onClick={() =>
+                      setClientFilters((current) => toggleClientFilter(current, client))
+                    }
+                  >
+                    {formatClientLabel(client)} ({clientCounts.get(client) ?? 0})
+                  </Button>
+                );
+              })}
+            </div>
           </div>
         </CardHeader>
 
@@ -262,7 +384,7 @@ export function McpManagerPanel({ client, contextMode, projectRoot }: McpManager
             emptyMessage={
               normalizedQuery.length > 0
                 ? `No MCP entries match "${searchQuery.trim()}".`
-                : "No MCP entries registered for the selected client."
+                : "No MCP entries registered for the current context."
             }
           />
         </CardContent>
@@ -270,16 +392,22 @@ export function McpManagerPanel({ client, contextMode, projectRoot }: McpManager
 
       <SlideOverPanel
         open={isComposerOpen}
-        title="Add MCP Entry"
-        description="Use compact input fields to register a new MCP source without leaving the list."
+        title="Add MCP Destination"
+        description="Choose the destination client first, then register the MCP entry for the current context."
         panelClassName="max-w-[42rem] max-[920px]:max-w-full"
         onClose={() => setComposerOpen(false)}
       >
         <McpAddForm
           disabled={phase === "loading"}
           state={addForm.state}
+          destinationClient={addForm.state.destinationClient}
+          destinationLabel={addDestinationPlan.destinationLabel}
+          destinationDescription={addDestinationPlan.destinationDescription}
+          destinationNotice={addDestinationPlan.fallbackNotice}
+          submitLabel={describeMcpAction("add", addDestinationPlan)}
           existingTargetIds={existingTargetIds}
           existingTransportChecksums={existingTransportChecksums}
+          onDestinationClientChange={addForm.setDestinationClient}
           onModeChange={addForm.setMode}
           onTargetIdChange={addForm.setTargetId}
           onTransportModeChange={addForm.setTransportMode}
@@ -300,8 +428,8 @@ export function McpManagerPanel({ client, contextMode, projectRoot }: McpManager
 
       <SlideOverPanel
         open={isCopyOpen}
-        title="Copy MCP Entry"
-        description="Copy the selected MCP entry to a different AI client."
+        title="Copy MCP to Another Client"
+        description="Copy the selected MCP entry to another client using the active personal or project context."
         panelClassName="max-w-[40rem] max-[920px]:max-w-full"
         onClose={() => {
           if (pendingCopyId !== null) {
@@ -314,6 +442,7 @@ export function McpManagerPanel({ client, contextMode, projectRoot }: McpManager
         <McpCopyForm
           disabled={phase === "loading" || pendingCopyId !== null}
           state={copyForm.state}
+          destinationPlan={copyDestinationPlan}
           onDestinationClientChange={copyForm.setDestinationClient}
           onTargetIdChange={copyForm.setTargetId}
           onEnabledChange={copyForm.setEnabled}
@@ -324,8 +453,8 @@ export function McpManagerPanel({ client, contextMode, projectRoot }: McpManager
 
       <SlideOverPanel
         open={isEditOpen}
-        title="Edit MCP Entry"
-        description="Update the selected MCP entry and persist it to the client configuration."
+        title="Edit MCP Source"
+        description="Update the selected MCP entry in its current source."
         panelClassName="max-w-[32rem] max-[920px]:max-w-full"
         onClose={() => {
           if (pendingUpdateId !== null) {
@@ -350,18 +479,19 @@ export function McpManagerPanel({ client, contextMode, projectRoot }: McpManager
 
       <ConfirmModal
         open={removalCandidate !== null}
-        title="Remove MCP Entry"
+        title="Remove MCP Source"
         description={
           removalCandidate ? (
             <p>
               Remove MCP <strong>{removalCandidate.display_name}</strong> from{" "}
+              <strong>{removalCandidate.source_label}</strong> for{" "}
               <strong>{formatClientLabel(removalCandidate.client)}</strong>?
             </p>
           ) : (
             ""
           )
         }
-        confirmLabel={pendingRemovalId === null ? "Remove MCP" : "Removing..."}
+        confirmLabel={pendingRemovalId === null ? "Remove from source" : "Removing..."}
         confirmDisabled={pendingRemovalId !== null}
         onConfirm={() => {
           void handleConfirmRemoval();

--- a/src/features/mcp/McpResourceTable.tsx
+++ b/src/features/mcp/McpResourceTable.tsx
@@ -10,6 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from "../../components/ui/table";
+import { formatClientLabel } from "../clients/client-labels";
 
 interface McpResourceTableProps {
   resources: ResourceRecord[];
@@ -20,10 +21,6 @@ interface McpResourceTableProps {
   onEdit: (resource: ResourceRecord) => Promise<void>;
   onRemove: (resource: ResourceRecord) => Promise<void>;
   emptyMessage?: string;
-}
-
-function formatSourcePath(sourcePath: string | null): string {
-  return sourcePath ?? "Auto-resolved";
 }
 
 function formatTransportKind(value: string | null): string {
@@ -113,6 +110,23 @@ function McpActionButton({
   );
 }
 
+function StatusBadge({ tone, label }: { tone: "neutral" | "success" | "warning"; label: string }) {
+  const className =
+    tone === "success"
+      ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+      : tone === "warning"
+        ? "border-amber-200 bg-amber-50 text-amber-800"
+        : "border-slate-200 bg-slate-100 text-slate-700";
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[0.68rem] font-semibold uppercase tracking-[0.08em] ${className}`}
+    >
+      {label}
+    </span>
+  );
+}
+
 export function McpResourceTable({
   resources,
   pendingRemovalId,
@@ -123,11 +137,13 @@ export function McpResourceTable({
   onRemove,
   emptyMessage,
 }: McpResourceTableProps) {
+  const resourcesById = new Map(resources.map((resource) => [resource.id, resource]));
+
   if (resources.length === 0) {
     return (
       <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50/70 px-4 py-7 text-center">
         <p className="text-sm leading-relaxed text-slate-600">
-          {emptyMessage ?? "No MCP entries registered for the selected client."}
+          {emptyMessage ?? "No MCP entries registered for the current context."}
         </p>
       </div>
     );
@@ -135,34 +151,99 @@ export function McpResourceTable({
 
   return (
     <div className="overflow-auto rounded-2xl border border-slate-200/90 bg-white">
-      <Table className="min-w-[42rem] max-[720px]:min-w-[36rem]">
+      <Table className="min-w-[66rem] max-[720px]:min-w-[52rem]">
         <TableHeader>
           <TableRow>
-            <TableHead>Name</TableHead>
+            <TableHead>Client</TableHead>
+            <TableHead>MCP Entry</TableHead>
             <TableHead>Transport</TableHead>
-            <TableHead>Enabled</TableHead>
+            <TableHead>Status</TableHead>
             <TableHead>Source</TableHead>
             <TableHead aria-label="actions" className="w-36" />
           </TableRow>
         </TableHeader>
         <TableBody>
           {resources.map((resource) => {
-            const removing = pendingRemovalId === resource.display_name;
-            const updating = pendingUpdateId === resource.display_name;
+            const removing = pendingRemovalId === resource.id;
+            const updating = pendingUpdateId === resource.id;
             const copying = pendingCopyId === resource.id;
+            const shadowingSource =
+              resource.shadowed_by === null
+                ? null
+                : (resourcesById.get(resource.shadowed_by) ?? null);
+
             return (
-              <TableRow key={resource.id} className="hover:bg-slate-50/70">
-                <TableCell className="font-medium text-slate-900">
-                  {resource.display_name}
+              <TableRow
+                key={resource.id}
+                className={
+                  resource.is_effective
+                    ? "hover:bg-slate-50/70"
+                    : "bg-amber-50/35 hover:bg-amber-50/60"
+                }
+              >
+                <TableCell>
+                  <div className="grid gap-1">
+                    <span className="text-sm font-medium text-slate-900">
+                      {formatClientLabel(resource.client)}
+                    </span>
+                    <span className="text-xs text-slate-500">{resource.client}</span>
+                  </div>
                 </TableCell>
-                <TableCell>{formatTransportKind(resource.transport_kind)}</TableCell>
-                <TableCell>{resource.enabled ? "yes" : "no"}</TableCell>
-                <TableCell>{formatSourcePath(resource.source_path)}</TableCell>
+                <TableCell>
+                  <div className="grid gap-1">
+                    <span className="font-medium text-slate-900">{resource.display_name}</span>
+                    <span className="text-xs text-slate-500">{resource.logical_id}</span>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="grid gap-1">
+                    <span className="text-sm text-slate-900">
+                      {formatTransportKind(resource.transport_kind)}
+                    </span>
+                    <span className="truncate text-xs text-slate-500">
+                      {resource.transport_kind === "sse"
+                        ? (resource.transport_url ?? "No URL")
+                        : (resource.transport_command ?? "No command")}
+                    </span>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-wrap gap-1.5">
+                    <StatusBadge
+                      tone={resource.enabled ? "success" : "neutral"}
+                      label={resource.enabled ? "Enabled" : "Disabled"}
+                    />
+                    <StatusBadge
+                      tone={resource.is_effective ? "success" : "warning"}
+                      label={resource.is_effective ? "Effective" : "Shadowed"}
+                    />
+                    {shadowingSource ? (
+                      <span className="text-xs text-slate-500">
+                        Hidden by {shadowingSource.source_label}
+                      </span>
+                    ) : null}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="grid gap-1">
+                    <span className="text-sm font-medium text-slate-900">
+                      {resource.source_label}
+                    </span>
+                    <span className="text-xs uppercase tracking-[0.08em] text-slate-500">
+                      {resource.source_scope.replace("_", " ")}
+                    </span>
+                    {resource.source_path ? (
+                      <span className="truncate text-xs text-slate-500">
+                        {resource.source_path}
+                      </span>
+                    ) : null}
+                  </div>
+                </TableCell>
                 <TableCell>
                   <div className="flex items-center gap-2">
                     <McpActionButton
                       icon={<CopyIcon />}
-                      label="Copy"
+                      label="Copy to another client"
                       busyLabel="Copying..."
                       busy={copying}
                       disabled={copying || updating || removing}
@@ -173,7 +254,7 @@ export function McpResourceTable({
                     />
                     <McpActionButton
                       icon={<EditIcon />}
-                      label="Edit"
+                      label={`Edit in ${resource.source_label}`}
                       busyLabel="Updating..."
                       busy={updating}
                       disabled={updating || removing || copying}
@@ -184,7 +265,7 @@ export function McpResourceTable({
                     />
                     <McpActionButton
                       icon={<RemoveIcon />}
-                      label="Remove"
+                      label={`Remove from ${resource.source_label}`}
                       busyLabel="Removing..."
                       busy={removing}
                       disabled={removing || updating || copying}

--- a/src/features/mcp/mcp-targets.ts
+++ b/src/features/mcp/mcp-targets.ts
@@ -1,0 +1,130 @@
+import type {
+  ClientKind,
+  ResourceRecord,
+  ResourceSourceScope,
+  ResourceViewMode,
+} from "../../backend/contracts";
+import { formatClientLabel } from "../clients/client-labels";
+import type { ResourceContextMode } from "../resources/resource-context";
+
+export interface McpMutationTargetPlan {
+  client: ClientKind;
+  destinationScope: ResourceSourceScope;
+  projectRoot: string | null;
+  targetSourceId: string | null;
+  destinationLabel: string;
+  destinationDescription: string;
+  fallbackNotice: string | null;
+}
+
+export const MCP_CLIENTS: ClientKind[] = ["claude_code", "cursor", "codex"];
+
+const PROJECT_SHARED_CONFIG: Record<
+  Exclude<ClientKind, "codex">,
+  {
+    relativePath: string;
+    selector: string;
+  }
+> = {
+  claude_code: {
+    relativePath: ".mcp.json",
+    selector: "/mcpServers",
+  },
+  cursor: {
+    relativePath: ".cursor/mcp.json",
+    selector: "/mcpServers",
+  },
+};
+
+export function formatResourceViewModeLabel(viewMode: ResourceViewMode): string {
+  return viewMode === "effective" ? "Effective Only" : "All Sources";
+}
+
+export function buildMcpProjectModeHint(): string {
+  return "Project mode writes new MCP entries to project config for Claude Code and Cursor. Codex falls back to personal config because it does not support project MCP sources yet.";
+}
+
+export function supportsProjectScopedMcp(client: ClientKind): boolean {
+  return client !== "codex";
+}
+
+export function buildMcpMutationTargetPlan(
+  client: ClientKind,
+  contextMode: ResourceContextMode,
+  projectRoot: string | null,
+): McpMutationTargetPlan {
+  if (
+    contextMode === "project" &&
+    projectRoot !== null &&
+    (client === "claude_code" || client === "cursor")
+  ) {
+    const config = PROJECT_SHARED_CONFIG[client];
+    return {
+      client,
+      destinationScope: "project_shared",
+      projectRoot,
+      targetSourceId: `mcp::${client}::project_shared::${joinPath(
+        projectRoot,
+        config.relativePath,
+      )}::${config.selector}`,
+      destinationLabel: "Project config",
+      destinationDescription: `${formatClientLabel(client)} writes project MCP entries to ${config.relativePath}.`,
+      fallbackNotice: null,
+    };
+  }
+
+  return {
+    client,
+    destinationScope: "user",
+    projectRoot: contextMode === "project" ? projectRoot : null,
+    targetSourceId: null,
+    destinationLabel: "Personal config",
+    destinationDescription:
+      contextMode === "project"
+        ? `${formatClientLabel(client)} will use personal MCP config in project mode.`
+        : `${formatClientLabel(client)} will use personal MCP config.`,
+    fallbackNotice:
+      contextMode === "project" && !supportsProjectScopedMcp(client)
+        ? `${formatClientLabel(client)} falls back to personal config in project mode.`
+        : null,
+  };
+}
+
+export function matchesMcpDestination(
+  resource: ResourceRecord,
+  destination: McpMutationTargetPlan,
+): boolean {
+  if (resource.client !== destination.client) {
+    return false;
+  }
+
+  if (resource.source_scope !== destination.destinationScope) {
+    return false;
+  }
+
+  if (destination.targetSourceId === null) {
+    return true;
+  }
+
+  return resource.source_id === destination.targetSourceId;
+}
+
+export function describeMcpAction(
+  action: "add" | "copy",
+  destination: McpMutationTargetPlan,
+): string {
+  if (action === "add") {
+    return destination.destinationScope === "project_shared"
+      ? "Add to project config"
+      : "Add to personal config";
+  }
+
+  return destination.destinationScope === "project_shared"
+    ? `Copy to ${formatClientLabel(destination.client)} project config`
+    : `Copy to ${formatClientLabel(destination.client)} personal config`;
+}
+
+function joinPath(root: string, relativePath: string): string {
+  const normalizedRoot = root.endsWith("/") ? root.slice(0, -1) : root;
+  return `${normalizedRoot}/${relativePath}`;
+}

--- a/src/features/mcp/useMcpAddForm.ts
+++ b/src/features/mcp/useMcpAddForm.ts
@@ -1,6 +1,6 @@
 import { type FormEvent, useCallback, useEffect, useState } from "react";
 
-import { buildTransportChecksum } from "./mcp-checksum";
+import type { ClientKind } from "../../backend/contracts";
 import { searchRegistryPresets } from "./mcp-registry";
 import { MCP_FALLBACK_PRESETS, type McpOfficialPreset } from "./official-presets";
 import type { AddMcpInput, McpTransportInput } from "./useMcpManager";
@@ -11,6 +11,7 @@ export type McpAddMode = "registry" | "preset" | "manual";
 export type McpPresetSource = "registry" | "preset";
 
 export interface McpAddFormState {
+  destinationClient: ClientKind;
   mode: McpAddMode;
   targetId: string;
   transportMode: TransportMode;
@@ -30,13 +31,16 @@ export interface McpAddFormState {
 
 interface UseMcpAddFormParams {
   onSubmit: (input: AddMcpInput) => Promise<boolean>;
+  resolveDestination: (client: ClientKind) => {
+    projectRoot: string | null;
+    targetSourceId: string | null;
+  };
   onAccepted?: () => void;
-  existingTargetIds?: ReadonlySet<string>;
-  existingTransportChecksums?: ReadonlySet<string>;
 }
 
 interface UseMcpAddFormResult {
   state: McpAddFormState;
+  setDestinationClient: (value: ClientKind) => void;
   setMode: (value: McpAddMode) => void;
   setTargetId: (value: string) => void;
   setTransportMode: (value: TransportMode) => void;
@@ -51,6 +55,7 @@ interface UseMcpAddFormResult {
 }
 
 const DEFAULT_STATE: McpAddFormState = {
+  destinationClient: "claude_code",
   mode: "registry",
   targetId: "example.server",
   transportMode: "stdio",
@@ -109,17 +114,20 @@ function createTransportPayload(
   };
 }
 
-function normalizeTargetId(value: string): string {
-  return value.trim().toLowerCase();
-}
-
 export function useMcpAddForm({
   onSubmit,
+  resolveDestination,
   onAccepted,
-  existingTargetIds,
-  existingTransportChecksums,
 }: UseMcpAddFormParams): UseMcpAddFormResult {
   const [state, setState] = useState<McpAddFormState>(DEFAULT_STATE);
+
+  const setDestinationClient = useCallback((value: ClientKind) => {
+    setState((current) => ({
+      ...current,
+      destinationClient: value,
+      localError: null,
+    }));
+  }, []);
 
   const setMode = useCallback((value: McpAddMode) => {
     setState((current) => ({ ...current, mode: value, localError: null }));
@@ -250,13 +258,6 @@ export function useMcpAddForm({
         setState((current) => ({ ...current, localError: "Target ID is required." }));
         return;
       }
-      if (existingTargetIds?.has(normalizeTargetId(normalizedTargetId))) {
-        setState((current) => ({
-          ...current,
-          localError: `MCP '${normalizedTargetId}' is already added for this client.`,
-        }));
-        return;
-      }
 
       if (state.mode === "registry" && state.selectedRegistryPresetId.trim().length === 0) {
         setState((current) => ({
@@ -287,18 +288,13 @@ export function useMcpAddForm({
         }));
         return;
       }
-      if (existingTransportChecksums?.has(buildTransportChecksum(transport))) {
-        setState((current) => ({
-          ...current,
-          localError: "An MCP with the same transport configuration is already added.",
-        }));
-        return;
-      }
 
       const accepted = await onSubmit({
+        destinationClient: state.destinationClient,
         targetId: normalizedTargetId,
         transport,
         enabled: state.enabled,
+        ...resolveDestination(state.destinationClient),
       });
 
       if (accepted) {
@@ -317,11 +313,12 @@ export function useMcpAddForm({
         onAccepted?.();
       }
     },
-    [existingTargetIds, existingTransportChecksums, onAccepted, onSubmit, state],
+    [onAccepted, onSubmit, resolveDestination, state],
   );
 
   return {
     state,
+    setDestinationClient,
     setMode,
     setTargetId,
     setTransportMode,

--- a/src/features/mcp/useMcpCopyForm.ts
+++ b/src/features/mcp/useMcpCopyForm.ts
@@ -17,6 +17,10 @@ export interface McpCopyFormState {
 
 interface UseMcpCopyFormParams {
   onSubmit: (input: CopyMcpInput) => Promise<boolean>;
+  resolveDestination: (client: ClientKind) => {
+    projectRoot: string | null;
+    targetSourceId: string | null;
+  };
   onAccepted?: () => void;
 }
 
@@ -91,6 +95,7 @@ const DEFAULT_STATE: McpCopyFormState = {
 
 export function useMcpCopyForm({
   onSubmit,
+  resolveDestination,
   onAccepted,
 }: UseMcpCopyFormParams): UseMcpCopyFormResult {
   const [state, setState] = useState<McpCopyFormState>(DEFAULT_STATE);
@@ -171,6 +176,7 @@ export function useMcpCopyForm({
         targetId: normalizedTargetId,
         transport: state.transport,
         enabled: state.enabled,
+        ...resolveDestination(state.destinationClient),
       });
 
       if (accepted) {
@@ -178,7 +184,7 @@ export function useMcpCopyForm({
         onAccepted?.();
       }
     },
-    [onAccepted, onSubmit, state],
+    [onAccepted, onSubmit, resolveDestination, state],
   );
 
   return {

--- a/src/features/mcp/useMcpEditForm.ts
+++ b/src/features/mcp/useMcpEditForm.ts
@@ -1,12 +1,16 @@
 import { type FormEvent, useCallback, useState } from "react";
 
-import type { ResourceRecord } from "../../backend/contracts";
+import type { ClientKind, ResourceRecord } from "../../backend/contracts";
 import type { TransportMode } from "./useMcpAddForm";
 import type { McpTransportInput, UpdateMcpInput } from "./useMcpManager";
 
 export interface McpEditFormState {
+  resourceId: string;
+  client: ClientKind;
   targetId: string;
-  sourcePath: string | null;
+  projectRoot: string | null;
+  targetSourceId: string;
+  sourceLabel: string;
   transportMode: TransportMode;
   command: string;
   argsInput: string;
@@ -22,7 +26,7 @@ interface UseMcpEditFormParams {
 
 interface UseMcpEditFormResult {
   state: McpEditFormState;
-  loadResource: (resource: ResourceRecord) => void;
+  loadResource: (resource: ResourceRecord, projectRoot: string | null) => void;
   reset: () => void;
   setTransportMode: (value: TransportMode) => void;
   setCommand: (value: string) => void;
@@ -33,8 +37,12 @@ interface UseMcpEditFormResult {
 }
 
 const DEFAULT_STATE: McpEditFormState = {
+  resourceId: "",
+  client: "claude_code",
   targetId: "",
-  sourcePath: null,
+  projectRoot: null,
+  targetSourceId: "",
+  sourceLabel: "",
   transportMode: "stdio",
   command: "",
   argsInput: "",
@@ -91,11 +99,15 @@ export function useMcpEditForm({
 }: UseMcpEditFormParams): UseMcpEditFormResult {
   const [state, setState] = useState<McpEditFormState>(DEFAULT_STATE);
 
-  const loadResource = useCallback((resource: ResourceRecord) => {
+  const loadResource = useCallback((resource: ResourceRecord, projectRoot: string | null) => {
     const transportMode: TransportMode = resource.transport_kind === "sse" ? "sse" : "stdio";
     setState({
+      resourceId: resource.id,
+      client: resource.client,
       targetId: resource.display_name,
-      sourcePath: resource.source_path,
+      projectRoot,
+      targetSourceId: resource.source_id,
+      sourceLabel: resource.source_label,
       transportMode,
       command: resource.transport_command ?? "",
       argsInput: (resource.transport_args ?? []).join(", "),
@@ -156,8 +168,12 @@ export function useMcpEditForm({
       }
 
       const accepted = await onSubmit({
+        resourceId: state.resourceId,
+        client: state.client,
         targetId: normalizedTargetId,
-        sourcePath: state.sourcePath,
+        projectRoot: state.projectRoot,
+        targetSourceId: state.targetSourceId,
+        sourceLabel: state.sourceLabel,
         transport,
         enabled: state.enabled,
       });

--- a/src/features/mcp/useMcpManager.ts
+++ b/src/features/mcp/useMcpManager.ts
@@ -1,13 +1,19 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { listResources, mutateResource } from "../../backend/client";
-import type { ClientKind, CommandEnvelope, ResourceRecord } from "../../backend/contracts";
+import type {
+  ClientKind,
+  CommandEnvelope,
+  ResourceRecord,
+  ResourceViewMode,
+} from "../../backend/contracts";
 import { redactNullableSensitiveText, redactSensitiveText } from "../../security/redaction";
 import {
   commandErrorToDiagnostic,
   type ErrorDiagnostic,
   runtimeErrorToDiagnostic,
 } from "../common/errorDiagnostics";
+import type { ResourceContextMode } from "../resources/resource-context";
 
 export type McpTransportInput =
   | {
@@ -21,16 +27,23 @@ export type McpTransportInput =
     };
 
 export interface AddMcpInput {
+  destinationClient: ClientKind;
   targetId: string;
   transport: McpTransportInput;
   enabled: boolean;
+  projectRoot: string | null;
+  targetSourceId: string | null;
 }
 
 export interface UpdateMcpInput {
+  resourceId: string;
+  client: ClientKind;
   targetId: string;
   transport: McpTransportInput;
   enabled: boolean;
-  sourcePath: string | null;
+  projectRoot: string | null;
+  targetSourceId: string;
+  sourceLabel: string;
 }
 
 export interface CopyMcpInput {
@@ -40,6 +53,23 @@ export interface CopyMcpInput {
   targetId: string;
   transport: McpTransportInput;
   enabled: boolean;
+  projectRoot: string | null;
+  targetSourceId: string | null;
+}
+
+export interface RemoveMcpInput {
+  resourceId: string;
+  client: ClientKind;
+  targetId: string;
+  projectRoot: string | null;
+  targetSourceId: string;
+  sourceLabel: string;
+}
+
+interface UseMcpManagerParams {
+  contextMode: ResourceContextMode;
+  projectRoot: string | null;
+  viewMode: ResourceViewMode;
 }
 
 interface MutationFeedback {
@@ -53,6 +83,7 @@ type LoadPhase = "idle" | "loading" | "ready" | "error";
 interface UseMcpManagerResult {
   phase: LoadPhase;
   resources: ResourceRecord[];
+  resolvedProjectRoot: string | null;
   warning: string | null;
   operationError: ErrorDiagnostic | null;
   feedback: MutationFeedback | null;
@@ -63,7 +94,7 @@ interface UseMcpManagerResult {
   addMcp: (input: AddMcpInput) => Promise<boolean>;
   updateMcp: (input: UpdateMcpInput) => Promise<boolean>;
   copyMcp: (input: CopyMcpInput) => Promise<boolean>;
-  removeMcp: (targetId: string, sourcePath: string | null) => Promise<boolean>;
+  removeMcp: (input: RemoveMcpInput) => Promise<boolean>;
   clearFeedback: () => void;
 }
 
@@ -86,9 +117,14 @@ function sortResources(resources: ResourceRecord[]): ResourceRecord[] {
   });
 }
 
-export function useMcpManager(client: ClientKind | null): UseMcpManagerResult {
+export function useMcpManager({
+  contextMode,
+  projectRoot,
+  viewMode,
+}: UseMcpManagerParams): UseMcpManagerResult {
   const [phase, setPhase] = useState<LoadPhase>("idle");
   const [resources, setResources] = useState<ResourceRecord[]>([]);
+  const [resolvedProjectRoot, setResolvedProjectRoot] = useState<string | null>(null);
   const [warning, setWarning] = useState<string | null>(null);
   const [operationError, setOperationError] = useState<ErrorDiagnostic | null>(null);
   const [feedback, setFeedback] = useState<MutationFeedback | null>(null);
@@ -97,25 +133,20 @@ export function useMcpManager(client: ClientKind | null): UseMcpManagerResult {
   const [pendingCopyId, setPendingCopyId] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
-    if (client === null) {
-      setPhase("idle");
-      setResources([]);
-      setWarning(null);
-      setOperationError(null);
-      return;
-    }
-
     setPhase("loading");
     setOperationError(null);
 
     try {
       const envelope = await listResources({
-        client,
+        client: null,
         resource_kind: "mcp",
+        project_root: contextMode === "project" ? projectRoot : null,
+        view_mode: viewMode,
       });
 
       if (!envelope.ok || envelope.data === null) {
         setPhase("error");
+        setResolvedProjectRoot(null);
         setOperationError(
           envelopeErrorDiagnostic(
             envelope,
@@ -126,15 +157,17 @@ export function useMcpManager(client: ClientKind | null): UseMcpManagerResult {
       }
 
       setResources(sortResources(envelope.data.items));
+      setResolvedProjectRoot(envelope.data.project_root);
       setWarning(redactNullableSensitiveText(envelope.data.warning));
       setOperationError(null);
       setPhase("ready");
     } catch (error) {
       setPhase("error");
+      setResolvedProjectRoot(null);
       const message = error instanceof Error ? error.message : "Unknown list runtime error.";
       setOperationError(runtimeErrorToDiagnostic(message));
     }
-  }, [client]);
+  }, [contextMode, projectRoot, viewMode]);
 
   useEffect(() => {
     void refresh();
@@ -142,36 +175,23 @@ export function useMcpManager(client: ClientKind | null): UseMcpManagerResult {
 
   const addMcp = useCallback(
     async (input: AddMcpInput) => {
-      if (client === null) {
-        const diagnostic = runtimeErrorToDiagnostic("Select a client before adding an MCP entry.");
-        setFeedback({
-          kind: "error",
-          message: diagnostic.message,
-          diagnostic,
-        });
-        return false;
-      }
-
       const transport =
         input.transport.kind === "stdio"
           ? { command: input.transport.command, args: input.transport.args }
           : { url: input.transport.url };
-
-      const sourcePathHint = resources.find((entry) => entry.source_path !== null)?.source_path;
       const payload: Record<string, unknown> = {
         transport,
         enabled: input.enabled,
       };
-      if (sourcePathHint !== null && sourcePathHint !== undefined) {
-        payload.source_path = sourcePathHint;
-      }
 
       try {
         const envelope = await mutateResource({
-          client,
+          client: input.destinationClient,
           resource_kind: "mcp",
           action: "add",
           target_id: input.targetId,
+          project_root: input.projectRoot,
+          target_source_id: input.targetSourceId,
           payload,
         });
 
@@ -198,31 +218,21 @@ export function useMcpManager(client: ClientKind | null): UseMcpManagerResult {
         return false;
       }
     },
-    [client, refresh, resources],
+    [refresh],
   );
 
   const removeMcp = useCallback(
-    async (targetId: string, sourcePath: string | null) => {
-      if (client === null) {
-        const diagnostic = runtimeErrorToDiagnostic(
-          "Select a client before removing an MCP entry.",
-        );
-        setFeedback({
-          kind: "error",
-          message: diagnostic.message,
-          diagnostic,
-        });
-        return false;
-      }
-
-      setPendingRemovalId(targetId);
+    async (input: RemoveMcpInput) => {
+      setPendingRemovalId(input.resourceId);
       try {
         const envelope = await mutateResource({
-          client,
+          client: input.client,
           resource_kind: "mcp",
           action: "remove",
-          target_id: targetId,
-          payload: sourcePath ? { source_path: sourcePath } : null,
+          target_id: input.targetId,
+          project_root: input.projectRoot,
+          target_source_id: input.targetSourceId,
+          payload: null,
         });
 
         if (!envelope.ok || envelope.data === null) {
@@ -242,7 +252,7 @@ export function useMcpManager(client: ClientKind | null): UseMcpManagerResult {
         const diagnostic = runtimeErrorToDiagnostic(message);
         setFeedback({
           kind: "error",
-          message: diagnostic.message,
+          message: `${input.sourceLabel}: ${diagnostic.message}`,
           diagnostic,
         });
         return false;
@@ -250,37 +260,26 @@ export function useMcpManager(client: ClientKind | null): UseMcpManagerResult {
         setPendingRemovalId(null);
       }
     },
-    [client, refresh],
+    [refresh],
   );
 
   const updateMcp = useCallback(
     async (input: UpdateMcpInput) => {
-      if (client === null) {
-        const diagnostic = runtimeErrorToDiagnostic(
-          "Select a client before updating an MCP entry.",
-        );
-        setFeedback({
-          kind: "error",
-          message: diagnostic.message,
-          diagnostic,
-        });
-        return false;
-      }
-
       const payloadTransport =
         input.transport.kind === "stdio"
           ? { command: input.transport.command, args: input.transport.args }
           : { url: input.transport.url };
 
-      setPendingUpdateId(input.targetId);
+      setPendingUpdateId(input.resourceId);
       try {
         const envelope = await mutateResource({
-          client,
+          client: input.client,
           resource_kind: "mcp",
           action: "update",
           target_id: input.targetId,
+          project_root: input.projectRoot,
+          target_source_id: input.targetSourceId,
           payload: {
-            source_path: input.sourcePath,
             transport: payloadTransport,
             enabled: input.enabled,
           },
@@ -303,7 +302,7 @@ export function useMcpManager(client: ClientKind | null): UseMcpManagerResult {
         const diagnostic = runtimeErrorToDiagnostic(message);
         setFeedback({
           kind: "error",
-          message: diagnostic.message,
+          message: `${input.sourceLabel}: ${diagnostic.message}`,
           diagnostic,
         });
         return false;
@@ -311,33 +310,11 @@ export function useMcpManager(client: ClientKind | null): UseMcpManagerResult {
         setPendingUpdateId(null);
       }
     },
-    [client, refresh],
+    [refresh],
   );
 
   const copyMcp = useCallback(
     async (input: CopyMcpInput) => {
-      if (client === null) {
-        const diagnostic = runtimeErrorToDiagnostic("Select a client before copying an MCP entry.");
-        setFeedback({
-          kind: "error",
-          message: diagnostic.message,
-          diagnostic,
-        });
-        return false;
-      }
-
-      if (input.sourceClient !== client) {
-        const diagnostic = runtimeErrorToDiagnostic(
-          "Selected source client is stale. Reload the MCP list and retry the copy operation.",
-        );
-        setFeedback({
-          kind: "error",
-          message: diagnostic.message,
-          diagnostic,
-        });
-        return false;
-      }
-
       if (input.destinationClient === input.sourceClient) {
         const diagnostic = runtimeErrorToDiagnostic(
           "Choose a different destination client when copying an MCP entry.",
@@ -375,6 +352,8 @@ export function useMcpManager(client: ClientKind | null): UseMcpManagerResult {
           resource_kind: "mcp",
           action: "add",
           target_id: normalizedTargetId,
+          project_root: input.projectRoot,
+          target_source_id: input.targetSourceId,
           payload: {
             transport: payloadTransport,
             enabled: input.enabled,
@@ -391,6 +370,7 @@ export function useMcpManager(client: ClientKind | null): UseMcpManagerResult {
         }
 
         setFeedback({ kind: "success", message: redactSensitiveText(envelope.data.message) });
+        await refresh();
         return true;
       } catch (error) {
         const message = error instanceof Error ? error.message : "Unknown copy runtime error.";
@@ -405,12 +385,13 @@ export function useMcpManager(client: ClientKind | null): UseMcpManagerResult {
         setPendingCopyId(null);
       }
     },
-    [client],
+    [refresh],
   );
 
   return {
     phase,
     resources,
+    resolvedProjectRoot,
     warning,
     operationError,
     feedback,

--- a/tests/mcp-targets.test.ts
+++ b/tests/mcp-targets.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildMcpMutationTargetPlan,
+  buildMcpProjectModeHint,
+  describeMcpAction,
+  matchesMcpDestination,
+} from "../src/features/mcp/mcp-targets.ts";
+
+test("project mode targets shared project config for Claude Code and Cursor", () => {
+  const claudeTarget = buildMcpMutationTargetPlan(
+    "claude_code",
+    "project",
+    "/Users/demo/workspace",
+  );
+  const cursorTarget = buildMcpMutationTargetPlan("cursor", "project", "/Users/demo/workspace");
+
+  assert.equal(claudeTarget.destinationScope, "project_shared");
+  assert.equal(
+    claudeTarget.targetSourceId,
+    "mcp::claude_code::project_shared::/Users/demo/workspace/.mcp.json::/mcpServers",
+  );
+  assert.equal(cursorTarget.destinationScope, "project_shared");
+  assert.equal(
+    cursorTarget.targetSourceId,
+    "mcp::cursor::project_shared::/Users/demo/workspace/.cursor/mcp.json::/mcpServers",
+  );
+});
+
+test("project mode falls back to personal config for Codex", () => {
+  const target = buildMcpMutationTargetPlan("codex", "project", "/Users/demo/workspace");
+
+  assert.equal(target.destinationScope, "user");
+  assert.equal(target.targetSourceId, null);
+  assert.match(target.fallbackNotice ?? "", /falls back to personal config/i);
+  assert.equal(describeMcpAction("add", target), "Add to personal config");
+});
+
+test("destination matching prefers client plus destination scope and source id", () => {
+  const target = buildMcpMutationTargetPlan("cursor", "project", "/Users/demo/workspace");
+
+  assert.equal(
+    matchesMcpDestination(
+      {
+        id: "cursor::project",
+        logical_id: "filesystem",
+        client: "cursor",
+        display_name: "filesystem",
+        enabled: true,
+        transport_kind: "stdio",
+        transport_command: "npx",
+        transport_args: [],
+        transport_url: null,
+        source_path: "/Users/demo/workspace/.cursor/mcp.json",
+        source_id:
+          "mcp::cursor::project_shared::/Users/demo/workspace/.cursor/mcp.json::/mcpServers",
+        source_scope: "project_shared",
+        source_label: "Project config",
+        is_effective: true,
+        shadowed_by: null,
+        description: null,
+        install_kind: null,
+        manifest_content: null,
+      },
+      target,
+    ),
+    true,
+  );
+
+  assert.equal(
+    matchesMcpDestination(
+      {
+        id: "cursor::user",
+        logical_id: "filesystem",
+        client: "cursor",
+        display_name: "filesystem",
+        enabled: true,
+        transport_kind: "stdio",
+        transport_command: "npx",
+        transport_args: [],
+        transport_url: null,
+        source_path: "/Users/demo/.cursor/mcp.json",
+        source_id: "mcp::cursor::user::/Users/demo/.cursor/mcp.json::/mcpServers",
+        source_scope: "user",
+        source_label: "Personal config",
+        is_effective: false,
+        shadowed_by: "cursor::project",
+        description: null,
+        install_kind: null,
+        manifest_content: null,
+      },
+      target,
+    ),
+    false,
+  );
+});
+
+test("project mode hint stays explicit about Codex fallback", () => {
+  assert.match(buildMcpProjectModeHint(), /Codex falls back to personal config/i);
+});


### PR DESCRIPTION
## Summary
- reshape the MCP panel around Personal/Project context with all-client listing, client filters, and Effective/All Sources modes
- wire MCP mutations to source-aware destinations and explicit personal/project wording
- add unit coverage for MCP destination planning and context fallback behavior

## Testing
- pnpm run ci:web
- pnpm run lint
- pnpm test
- pnpm outdated

Closes #127