### PR TITLE
feat: adapt Skills manager to the resource context shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "package:macos:dmg": "node ./scripts/package-macos-dmg.mjs",
     "test": "pnpm run test:contracts && pnpm run test:web:unit",
     "test:contracts": "node --test tests/error-ui-contract.test.mjs tests/normalized-domain-model.test.mjs tests/support-matrix.test.mjs tests/mvp-acceptance-contract.test.mjs",
-    "test:web:unit": "tsx --test tests/resource-context.test.ts tests/mcp-targets.test.ts",
+    "test:web:unit": "tsx --test tests/resource-context.test.ts tests/mcp-targets.test.ts tests/skill-context.test.ts",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/src/features/skills/SkillAddForm.tsx
+++ b/src/features/skills/SkillAddForm.tsx
@@ -55,9 +55,9 @@ export function SkillAddForm({
       return "Up to Date";
     }
     if (syncInfo.status === "update_available") {
-      return state.mode === "manual" ? "Update Skill" : "Update Selected Skill";
+      return "Update personal skill";
     }
-    return state.mode === "manual" ? "Add Skill" : "Import Selected Skill";
+    return state.mode === "manual" ? "Add personal skill" : "Import to personal skills";
   }
 
   const form = (

--- a/src/features/skills/SkillCopyForm.tsx
+++ b/src/features/skills/SkillCopyForm.tsx
@@ -93,7 +93,7 @@ export function SkillCopyForm({
       />
 
       <Button type="submit" disabled={disabled || destinationOptions.length === 0}>
-        Copy Skill
+        Copy to another client
       </Button>
     </form>
   );

--- a/src/features/skills/SkillEditForm.tsx
+++ b/src/features/skills/SkillEditForm.tsx
@@ -46,7 +46,7 @@ export function SkillEditForm({
       />
 
       <Button type="submit" disabled={disabled}>
-        Update Skill
+        Update personal skill
       </Button>
     </form>
   );

--- a/src/features/skills/SkillResourceTable.tsx
+++ b/src/features/skills/SkillResourceTable.tsx
@@ -127,7 +127,7 @@ export function SkillResourceTable({
     return (
       <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50/70 px-4 py-7 text-center">
         <p className="text-sm leading-relaxed text-slate-600">
-          {emptyMessage ?? "No Skill entries registered for the selected client."}
+          {emptyMessage ?? "No skill entries registered for the selected client."}
         </p>
       </div>
     );
@@ -167,7 +167,7 @@ export function SkillResourceTable({
                 <TableCell className="flex items-center justify-end gap-1.5 whitespace-nowrap">
                   <SkillActionButton
                     icon={<CopyIcon />}
-                    label="Copy"
+                    label="Copy to another client"
                     busyLabel="Copying..."
                     busy={copying}
                     disabled={copying || updating || removing}
@@ -178,7 +178,7 @@ export function SkillResourceTable({
                   />
                   <SkillActionButton
                     icon={<EditIcon />}
-                    label="Edit"
+                    label="Edit personal skill"
                     busyLabel="Updating..."
                     busy={updating}
                     disabled={updating || removing || copying}
@@ -189,7 +189,7 @@ export function SkillResourceTable({
                   />
                   <SkillActionButton
                     icon={<RemoveIcon />}
-                    label="Remove"
+                    label="Remove from personal"
                     busyLabel="Removing..."
                     busy={removing}
                     disabled={removing || updating || copying}

--- a/src/features/skills/SkillsManagerPanel.tsx
+++ b/src/features/skills/SkillsManagerPanel.tsx
@@ -21,6 +21,7 @@ import { SkillCopyForm } from "./SkillCopyForm";
 import { SkillEditForm } from "./SkillEditForm";
 import { SkillResourceTable } from "./SkillResourceTable";
 import { buildResourceSkillManifestChecksum } from "./skill-checksum";
+import { buildSkillContextHint } from "./skill-context";
 import { buildSkillGithubRecentsStorageKey } from "./skill-github-recents";
 import { useSkillAddForm } from "./useSkillAddForm";
 import { useSkillCopyForm } from "./useSkillCopyForm";
@@ -43,6 +44,7 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
     mode: contextMode,
     projectRoot,
   });
+  const contextHint = buildSkillContextHint(contextMode);
   const activeClient = isProjectContextIncomplete({ mode: contextMode, projectRoot })
     ? null
     : client;
@@ -204,7 +206,7 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
             <div>
               <CardTitle className="text-[1.35rem] tracking-[-0.012em]">Skills Manager</CardTitle>
               <p className="mt-1 text-sm text-slate-700">
-                Managing <strong>{formatClientLabel(client)}</strong>
+                Managing personal skills for <strong>{formatClientLabel(client)}</strong>
               </p>
               <p className="mt-1 text-xs text-slate-500">{contextSummary.description}</p>
             </div>
@@ -222,10 +224,12 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
                 {phase === "loading" ? "Loading..." : "Reload"}
               </Button>
               <Button type="button" size="sm" onClick={openComposer}>
-                Add Skill
+                Add Personal Skill
               </Button>
             </div>
           </div>
+
+          {contextMode === "project" ? <Alert variant="warning">{contextHint}</Alert> : null}
 
           <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-slate-200/90 bg-white/90 p-2.5">
             <p className="rounded-full bg-slate-900 px-3 py-1 text-[0.69rem] font-semibold uppercase tracking-[0.08em] text-slate-100">
@@ -269,7 +273,9 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
             emptyMessage={
               normalizedQuery.length > 0
                 ? `No skill entries match "${searchQuery.trim()}".`
-                : "No Skill entries registered for the selected client."
+                : contextMode === "project"
+                  ? "No personal skill entries are available for the selected client in this project context."
+                  : "No skill entries registered for the selected client."
             }
           />
         </CardContent>
@@ -277,33 +283,36 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
 
       <SlideOverPanel
         open={isComposerOpen}
-        title="Add Skill Entry"
-        description="Install a skill from a compact composer while keeping the list in view."
+        title="Add Personal Skill"
+        description="Install a skill into the selected client's personal storage while keeping the list in view."
         panelClassName="max-w-[42rem] max-[920px]:max-w-full"
         onClose={() => setComposerOpen(false)}
       >
-        <SkillAddForm
-          disabled={phase === "loading"}
-          state={addForm.state}
-          syncInfo={addForm.syncInfo}
-          onModeChange={addForm.setMode}
-          onTargetIdChange={addForm.setTargetId}
-          onInstallKindChange={addForm.setInstallKind}
-          onManifestChange={addForm.setManifest}
-          onGithubRepoUrlChange={addForm.setGithubRepoUrl}
-          onApplyRecentGithubRepoUrl={addForm.applyRecentGithubRepoUrl}
-          onSelectedGithubManifestPathChange={addForm.setSelectedGithubManifestPath}
-          onGithubRiskAcknowledgedChange={addForm.setGithubRiskAcknowledged}
-          onDiscoverGithubRepo={addForm.discoverGithubRepo}
-          onSubmit={addForm.submit}
-          className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
-        />
+        <div className="grid gap-3">
+          <Alert variant={contextMode === "project" ? "warning" : "default"}>{contextHint}</Alert>
+          <SkillAddForm
+            disabled={phase === "loading"}
+            state={addForm.state}
+            syncInfo={addForm.syncInfo}
+            onModeChange={addForm.setMode}
+            onTargetIdChange={addForm.setTargetId}
+            onInstallKindChange={addForm.setInstallKind}
+            onManifestChange={addForm.setManifest}
+            onGithubRepoUrlChange={addForm.setGithubRepoUrl}
+            onApplyRecentGithubRepoUrl={addForm.applyRecentGithubRepoUrl}
+            onSelectedGithubManifestPathChange={addForm.setSelectedGithubManifestPath}
+            onGithubRiskAcknowledgedChange={addForm.setGithubRiskAcknowledged}
+            onDiscoverGithubRepo={addForm.discoverGithubRepo}
+            onSubmit={addForm.submit}
+            className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+          />
+        </div>
       </SlideOverPanel>
 
       <SlideOverPanel
         open={isCopyOpen}
-        title="Copy Skill Entry"
-        description="Copy the selected skill to a different AI client."
+        title="Copy Skill to Another Client"
+        description="Copy the selected skill into another client's personal skill storage."
         panelClassName="max-w-[40rem] max-[920px]:max-w-full"
         onClose={() => {
           if (pendingCopyId !== null) {
@@ -313,21 +322,24 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
           copyForm.reset();
         }}
       >
-        <SkillCopyForm
-          disabled={phase === "loading" || pendingCopyId !== null}
-          state={copyForm.state}
-          onDestinationClientChange={copyForm.setDestinationClient}
-          onTargetIdChange={copyForm.setTargetId}
-          onInstallKindChange={copyForm.setInstallKind}
-          onSubmit={copyForm.submit}
-          className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
-        />
+        <div className="grid gap-3">
+          <Alert variant={contextMode === "project" ? "warning" : "default"}>{contextHint}</Alert>
+          <SkillCopyForm
+            disabled={phase === "loading" || pendingCopyId !== null}
+            state={copyForm.state}
+            onDestinationClientChange={copyForm.setDestinationClient}
+            onTargetIdChange={copyForm.setTargetId}
+            onInstallKindChange={copyForm.setInstallKind}
+            onSubmit={copyForm.submit}
+            className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+          />
+        </div>
       </SlideOverPanel>
 
       <SlideOverPanel
         open={isEditOpen}
-        title="Edit Skill Entry"
-        description="Update the selected skill manifest and write it to the installed path."
+        title="Edit Personal Skill"
+        description="Update the selected skill manifest in the client's personal storage."
         panelClassName="max-w-[40rem] max-[920px]:max-w-full"
         onClose={() => {
           if (pendingUpdateId !== null) {
@@ -337,29 +349,32 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
           editForm.reset();
         }}
       >
-        <SkillEditForm
-          disabled={phase === "loading" || pendingUpdateId !== null}
-          state={editForm.state}
-          onManifestChange={editForm.setManifest}
-          onSubmit={editForm.submit}
-          className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
-        />
+        <div className="grid gap-3">
+          <Alert variant={contextMode === "project" ? "warning" : "default"}>{contextHint}</Alert>
+          <SkillEditForm
+            disabled={phase === "loading" || pendingUpdateId !== null}
+            state={editForm.state}
+            onManifestChange={editForm.setManifest}
+            onSubmit={editForm.submit}
+            className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+          />
+        </div>
       </SlideOverPanel>
 
       <ConfirmModal
         open={removalCandidate !== null}
-        title="Remove Skill Entry"
+        title="Remove Personal Skill"
         description={
           removalCandidate ? (
             <p>
-              Remove Skill <strong>{removalCandidate.display_name}</strong> from{" "}
+              Remove skill <strong>{removalCandidate.display_name}</strong> from{" "}
               <strong>{formatClientLabel(removalCandidate.client)}</strong>?
             </p>
           ) : (
             ""
           )
         }
-        confirmLabel={pendingRemovalId === null ? "Remove Skill" : "Removing..."}
+        confirmLabel={pendingRemovalId === null ? "Remove from personal" : "Removing..."}
         confirmDisabled={pendingRemovalId !== null}
         onConfirm={() => {
           void handleConfirmRemoval();

--- a/src/features/skills/skill-context.ts
+++ b/src/features/skills/skill-context.ts
@@ -1,0 +1,26 @@
+import type { ResourceContextMode } from "../resources/resource-context";
+
+export function buildSkillContextHint(contextMode: ResourceContextMode): string {
+  if (contextMode === "project") {
+    return "Project mode currently reuses personal skill storage for the selected client. Project-native skill destinations are not available yet.";
+  }
+
+  return "Skills are managed in the selected client's personal storage.";
+}
+
+export function describeSkillAction(
+  action: "add" | "update" | "remove" | "copy" | "import",
+): string {
+  switch (action) {
+    case "add":
+      return "Add personal skill";
+    case "update":
+      return "Update personal skill";
+    case "remove":
+      return "Remove from personal";
+    case "copy":
+      return "Copy to another client";
+    case "import":
+      return "Import to personal skills";
+  }
+}

--- a/tests/skill-context.test.ts
+++ b/tests/skill-context.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildSkillContextHint,
+  describeSkillAction,
+} from "../src/features/skills/skill-context.ts";
+
+test("project mode hint stays explicit about personal-only skill storage", () => {
+  assert.match(buildSkillContextHint("project"), /personal skill storage/i);
+  assert.match(buildSkillContextHint("project"), /not available yet/i);
+});
+
+test("personal mode hint stays concise", () => {
+  assert.equal(
+    buildSkillContextHint("personal"),
+    "Skills are managed in the selected client's personal storage.",
+  );
+});
+
+test("skill action labels stay explicit", () => {
+  assert.equal(describeSkillAction("add"), "Add personal skill");
+  assert.equal(describeSkillAction("update"), "Update personal skill");
+  assert.equal(describeSkillAction("remove"), "Remove from personal");
+  assert.equal(describeSkillAction("copy"), "Copy to another client");
+  assert.equal(describeSkillAction("import"), "Import to personal skills");
+});


### PR DESCRIPTION
## Summary
- keep Skills usable in Personal and Project modes while being explicit that storage is still personal-only
- update skill action wording and dialog copy to match the context-first IA
- add unit coverage for the new skill-context messaging helpers

## Testing
- pnpm run ci:web
- pnpm run lint
- pnpm test
- pnpm outdated

Closes #128