### PR TITLE
docs: clarify skill taxonomy and Claude subagent scope

### DIFF
--- a/docs/operations/config-backup-troubleshooting.md
+++ b/docs/operations/config-backup-troubleshooting.md
@@ -21,6 +21,8 @@ This guide documents real application behavior for issue `#35`.
     - `~/Library/Application Support/Cursor/User/mcp.json`
 ### Skills directory paths
 
+These paths refer to AI Manager-managed generic `SKILL.md` repositories. They are not a claim about native client project features such as Claude subagents.
+
 - Claude Code:
   - Override: `AI_MANAGER_CLAUDE_CODE_SKILLS_DIR`
   - Fallback: `~/.claude/skills`
@@ -87,6 +89,8 @@ If only `Backup: ...` is visible, use the client path mapping above to determine
 
 - `MCP '<id>' already exists.` / `MCP '<id>' does not exist.`
   - Use list flow first, then re-run add/remove
+- `MCP '<id>' already exists in <destination>. Set overwrite=true or choose a different destination_target_id.`
+  - Rename the destination ID or confirm overwrite in the MCP copy/promote flow
 - `Skill '<id>' already exists. Conflicts: ...`
   - Remove conflict target or choose a different id
 - `source_path '<...>' does not exist.`

--- a/docs/spec/normalized-domain-model.md
+++ b/docs/spec/normalized-domain-model.md
@@ -25,8 +25,9 @@ This document defines the source-aware normalized model required by issues `#106
 - `source` carries scope, source container, effective state, and shadowing metadata.
 
 3. `Skill`
-- Installation target and metadata independent from MCP transport details.
+- Installation target and metadata for AI Manager-managed generic `SKILL.md` repositories.
 - Uses the same source-aware identity and source metadata pattern as MCP records.
+- Does not represent client-native Claude subagents; that requires a separate native resource kind.
 
 ## Lossless Mapping Strategy
 
@@ -46,7 +47,7 @@ This document defines the source-aware normalized model required by issues `#106
 - `current*Scopes` describe what the repo can list/mutate today.
 - `target*Scopes` describe the intended source-aware model for staged rollout.
 - Codex remains user-only unless upstream project-local MCP support becomes official.
-- Project-scoped skill support stays out of scope until taxonomy is resolved in `#110`.
+- Generic skills remain personal-only after `#110`; native Claude project support moves to a future subagent resource kind instead of extending `skill`.
 
 ## Files
 

--- a/docs/spec/skill-like-taxonomy.md
+++ b/docs/spec/skill-like-taxonomy.md
@@ -1,0 +1,46 @@
+# Skill-Like Resource Taxonomy
+
+This document closes issue `#110` by separating AI Manager-managed generic skills from client-native agent features.
+
+## Resource Families
+
+### Generic Skills
+
+- Represented today by the `Skills` tab and the normalized `skill` resource kind.
+- Stored as `SKILL.md` manifests inside client-specific personal directories such as `~/.cursor/skills`.
+- Managed by AI Manager, not by upstream client-native project features.
+- Personal-only for now across Claude Code, Codex, and Cursor.
+
+### Native Agent Features
+
+- Represent upstream client-native concepts that do not map cleanly to generic `SKILL.md` repositories.
+- Claude Code project-native customization belongs here.
+- Claude should be modeled as `subagents` or an equivalent native resource kind rather than folded into generic `skill`.
+- Native project scope must remain separate from AI Manager-managed generic repositories in both docs and UI.
+
+## Client Classification
+
+| Client | Generic personal skills | Native project feature | Product stance |
+| --- | --- | --- | --- |
+| Claude Code | Supported as AI Manager-managed `SKILL.md` repository | Subagents / agents | Do not treat Claude project-native support as `skill`; add a separate native resource kind later |
+| Codex | Supported as AI Manager-managed `SKILL.md` repository | None confirmed | Keep generic skills personal-only |
+| Cursor | Supported as AI Manager-managed `SKILL.md` repository | None confirmed comparable to Claude subagents | Keep generic skills personal-only |
+
+## Product Rules
+
+1. Keep the current `Skills` tab scoped to AI Manager-managed personal repositories.
+2. Do not imply that the `Skills` tab exposes native Claude project customization.
+3. Treat native project-scoped agent features as a separate product surface and contract.
+4. Keep support matrix entries explicit about `native` vs `generic/project-managed` support.
+
+## Staged Rollout
+
+1. Ship project-aware MCP independently.
+2. Keep generic skills personal-only with explicit copy in the UI and docs.
+3. Introduce a dedicated Claude native subagent resource kind in follow-up work.
+4. Revisit project-scoped generic repositories only if there is a product reason beyond parity with client-native features.
+
+## Follow-Up Issues
+
+- `#138` Add a dedicated Claude subagent resource kind and listing strategy.
+- `#139` Separate generic skill libraries from native client resources in the UI and contracts.

--- a/docs/spec/support-matrix.md
+++ b/docs/spec/support-matrix.md
@@ -28,6 +28,8 @@ This document freezes the detection input matrix and staged scope rollout plan f
 ## Staged Scope Support
 
 - `resourceKinds.mcp` captures current vs target MCP scope support per client.
+- `resourceKinds.skills` refers to AI Manager-managed generic `SKILL.md` repositories only.
+- Native client features such as Claude subagents are tracked separately from `resourceKinds.skills`.
 - `resourceKinds.skills` stays user-only for now and records that project scope is deferred.
 - `projectScopeStatus` values are:
   - `planned`: native project support is intended in a follow-up implementation issue
@@ -54,3 +56,5 @@ Each client includes both:
   - `schemas/support-matrix.schema.json`
 - Unit tests:
   - `tests/support-matrix.test.mjs`
+- Skill taxonomy:
+  - `docs/spec/skill-like-taxonomy.md`

--- a/docs/spec/support-matrix.v1.json
+++ b/docs/spec/support-matrix.v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../schemas/support-matrix.schema.json",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "updatedAt": "2026-03-08",
   "resolutionPolicy": {
     "precedence": "per_resource_kind_scope_order_then_candidate_priority",
@@ -144,7 +144,8 @@
           ],
           "projectScopeStatus": "deferred",
           "notes": [
-            "Claude project-scoped customization should be clarified via subagents in issue #110 before adding native project support."
+            "This entry describes AI Manager-managed generic SKILL.md repositories only.",
+            "Claude project-scoped customization belongs to native subagents/agents and should not extend the generic skill resource kind."
           ]
         }
       },
@@ -276,6 +277,7 @@
           ],
           "projectScopeStatus": "deferred",
           "notes": [
+            "This entry describes AI Manager-managed generic SKILL.md repositories only.",
             "No native project-scoped skills source is documented for Codex. Generic repository handling remains separate from native support."
           ]
         }
@@ -429,7 +431,8 @@
           ],
           "projectScopeStatus": "deferred",
           "notes": [
-            "Project-scoped skills remain deferred until the product taxonomy is clarified in issue #110."
+            "This entry describes AI Manager-managed generic SKILL.md repositories only.",
+            "Cursor has no confirmed native project-scoped feature comparable to Claude subagents, so project-scoped generic skills remain deferred."
           ]
         }
       },

--- a/src/features/skills/SkillsManagerPanel.tsx
+++ b/src/features/skills/SkillsManagerPanel.tsx
@@ -206,7 +206,7 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
             <div>
               <CardTitle className="text-[1.35rem] tracking-[-0.012em]">Skills Manager</CardTitle>
               <p className="mt-1 text-sm text-slate-700">
-                Managing personal skills for <strong>{formatClientLabel(client)}</strong>
+                Managing AI Manager personal skills for <strong>{formatClientLabel(client)}</strong>
               </p>
               <p className="mt-1 text-xs text-slate-500">{contextSummary.description}</p>
             </div>

--- a/src/features/skills/skill-context.ts
+++ b/src/features/skills/skill-context.ts
@@ -2,10 +2,10 @@ import type { ResourceContextMode } from "../resources/resource-context";
 
 export function buildSkillContextHint(contextMode: ResourceContextMode): string {
   if (contextMode === "project") {
-    return "Project mode currently reuses personal skill storage for the selected client. Project-native skill destinations are not available yet.";
+    return "This tab manages AI Manager personal skill libraries only. Claude native project support maps to subagents and is not available here yet.";
   }
 
-  return "Skills are managed in the selected client's personal storage.";
+  return "This tab manages AI Manager personal skill libraries for the selected client.";
 }
 
 export function describeSkillAction(

--- a/tests/skill-context.test.ts
+++ b/tests/skill-context.test.ts
@@ -7,14 +7,14 @@ import {
 } from "../src/features/skills/skill-context.ts";
 
 test("project mode hint stays explicit about personal-only skill storage", () => {
-  assert.match(buildSkillContextHint("project"), /personal skill storage/i);
-  assert.match(buildSkillContextHint("project"), /not available yet/i);
+  assert.match(buildSkillContextHint("project"), /personal skill libraries/i);
+  assert.match(buildSkillContextHint("project"), /subagents/i);
 });
 
 test("personal mode hint stays concise", () => {
   assert.equal(
     buildSkillContextHint("personal"),
-    "Skills are managed in the selected client's personal storage.",
+    "This tab manages AI Manager personal skill libraries for the selected client.",
   );
 });
 

--- a/tests/support-matrix.test.mjs
+++ b/tests/support-matrix.test.mjs
@@ -19,7 +19,7 @@ function assertContiguousPriorities(candidates, fieldName) {
 }
 
 test("matrix includes exactly three target clients", () => {
-  assert.equal(matrix.version, "1.1.0");
+  assert.equal(matrix.version, "1.2.0");
   assert.equal(matrix.clients.length, expectedClientIds.length);
   assert.deepEqual(matrix.clients.map((client) => client.id).sort(), [...expectedClientIds].sort());
 });
@@ -107,4 +107,15 @@ test("staged MCP support matches the client rollout plan", () => {
 
   assert.deepEqual(byId.get("codex").resourceKinds.mcp.targetSourceScopes, ["user"]);
   assert.equal(byId.get("codex").resourceKinds.mcp.projectScopeStatus, "not_applicable");
+});
+
+test("skills notes distinguish generic repositories from native client features", () => {
+  const byId = new Map(matrix.clients.map((client) => [client.id, client]));
+
+  for (const client of matrix.clients) {
+    const joinedNotes = client.resourceKinds.skills.notes.join(" ");
+    assert.match(joinedNotes, /generic/i);
+  }
+
+  assert.match(byId.get("claude_code").resourceKinds.skills.notes.join(" "), /subagents|agents/i);
 });


### PR DESCRIPTION
## Summary
- document the taxonomy split between AI Manager-managed generic skills and native client features
- update support matrix and normalized model specs to keep Claude subagents separate from generic skills
- clarify the Skills UI copy so project mode no longer implies native Claude project support

## Testing
- pnpm run ci:web
- pnpm run lint
- pnpm test
- pnpm outdated

Closes #110
Refs #138
Refs #139