### PR TITLE
feat: separate generic skill libraries from native resources

### DIFF
--- a/docs/spec/skill-like-taxonomy.md
+++ b/docs/spec/skill-like-taxonomy.md
@@ -32,6 +32,7 @@ This document closes issue `#110` by separating AI Manager-managed generic skill
 2. Do not imply that the `Skills` tab exposes native Claude project customization.
 3. Treat native project-scoped agent features as a separate product surface and contract.
 4. Keep support matrix entries explicit about `native` vs `generic/project-managed` support.
+5. Shared contracts should tag resource kinds as `generic` or `native` so new native surfaces do not redefine `skill`.
 
 ## Staged Rollout
 

--- a/docs/spec/support-matrix.md
+++ b/docs/spec/support-matrix.md
@@ -30,6 +30,7 @@ This document freezes the detection input matrix and staged scope rollout plan f
 - `resourceKinds.mcp` captures current vs target MCP scope support per client.
 - `resourceKinds.skills` refers to AI Manager-managed generic `SKILL.md` repositories only.
 - `resourceKinds.subagents` tracks native Claude agent sources separately from generic skills.
+- `resourceKinds.*.family` explicitly marks whether a resource kind is `generic` or `native`.
 - `resourceKinds.skills` stays user-only for now and records that project scope is deferred.
 - `resourceKinds.subagents` is source-aware for Claude listing and keeps mutation scope explicitly staged.
 - `projectScopeStatus` values are:

--- a/docs/spec/support-matrix.v1.json
+++ b/docs/spec/support-matrix.v1.json
@@ -99,6 +99,7 @@
       ],
       "resourceKinds": {
         "mcp": {
+          "family": "native",
           "currentSourceScopes": [
             "user"
           ],
@@ -127,6 +128,7 @@
           ]
         },
         "skills": {
+          "family": "generic",
           "currentSourceScopes": [
             "user"
           ],
@@ -149,6 +151,7 @@
           ]
         },
         "subagents": {
+          "family": "native",
           "currentSourceScopes": [
             "user",
             "project_shared"
@@ -263,6 +266,7 @@
       ],
       "resourceKinds": {
         "mcp": {
+          "family": "native",
           "currentSourceScopes": [
             "user"
           ],
@@ -284,6 +288,7 @@
           ]
         },
         "skills": {
+          "family": "generic",
           "currentSourceScopes": [
             "user"
           ],
@@ -306,6 +311,7 @@
           ]
         },
         "subagents": {
+          "family": "native",
           "currentSourceScopes": [],
           "targetSourceScopes": [],
           "currentDestinationScopes": [],
@@ -425,6 +431,7 @@
       ],
       "resourceKinds": {
         "mcp": {
+          "family": "native",
           "currentSourceScopes": [
             "user"
           ],
@@ -449,6 +456,7 @@
           ]
         },
         "skills": {
+          "family": "generic",
           "currentSourceScopes": [
             "user"
           ],
@@ -471,6 +479,7 @@
           ]
         },
         "subagents": {
+          "family": "native",
           "currentSourceScopes": [],
           "targetSourceScopes": [],
           "currentDestinationScopes": [],

--- a/schemas/support-matrix.schema.json
+++ b/schemas/support-matrix.schema.json
@@ -196,6 +196,7 @@
     "resourceKindSupport": {
       "type": "object",
       "required": [
+        "family",
         "currentSourceScopes",
         "targetSourceScopes",
         "currentDestinationScopes",
@@ -205,6 +206,13 @@
         "notes"
       ],
       "properties": {
+        "family": {
+          "type": "string",
+          "enum": [
+            "generic",
+            "native"
+          ]
+        },
         "currentSourceScopes": {
           "type": "array",
           "items": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,7 +100,8 @@ function App() {
             Client Control Center
           </h1>
           <p className="text-sm leading-relaxed text-slate-200">
-            macOS-first shell for detection, MCP, and Skills operations.
+            macOS-first shell for detection, MCP, generic skill libraries, and native resource
+            planning.
           </p>
         </div>
 
@@ -224,8 +225,8 @@ function App() {
                     Active Client
                   </p>
                   <p className="text-sm text-slate-700">
-                    Manager views prioritize resource operations. Open dashboard for full tool
-                    cards.
+                    Manager views prioritize generic skill library operations. Open dashboard for
+                    full tool cards.
                   </p>
                 </div>
 

--- a/src/backend/contracts.ts
+++ b/src/backend/contracts.ts
@@ -1,8 +1,33 @@
 export type ClientKind = "claude_code" | "codex" | "cursor";
 
 export type ResourceKind = "mcp" | "skill" | "subagent";
+export type ResourceFamily = "generic" | "native";
 export type ResourceSourceScope = "user" | "project_shared" | "project_private";
 export type ResourceViewMode = "effective" | "all_sources";
+
+export interface ResourceKindCatalogEntry {
+  family: ResourceFamily;
+  label: string;
+  managementModel: "ai_manager" | "client_native";
+}
+
+export const RESOURCE_KIND_CATALOG: Record<ResourceKind, ResourceKindCatalogEntry> = {
+  mcp: {
+    family: "native",
+    label: "MCP",
+    managementModel: "client_native",
+  },
+  skill: {
+    family: "generic",
+    label: "Skill Library",
+    managementModel: "ai_manager",
+  },
+  subagent: {
+    family: "native",
+    label: "Subagent",
+    managementModel: "client_native",
+  },
+};
 
 export type LifecyclePhase = "running" | "shutting_down";
 

--- a/src/features/navigation.ts
+++ b/src/features/navigation.ts
@@ -19,7 +19,7 @@ export const NAVIGATION_ITEMS: NavigationItem[] = [
   },
   {
     route: "skills",
-    title: "Skills Manager",
-    subtitle: "Manage skill resources",
+    title: "Skill Libraries",
+    subtitle: "Generic SKILL.md libraries",
   },
 ];

--- a/src/features/skills/SkillsManagerPanel.tsx
+++ b/src/features/skills/SkillsManagerPanel.tsx
@@ -1,6 +1,10 @@
 import { useMemo, useState } from "react";
 
-import type { ClientKind, ResourceRecord } from "../../backend/contracts";
+import {
+  type ClientKind,
+  RESOURCE_KIND_CATALOG,
+  type ResourceRecord,
+} from "../../backend/contracts";
 import { ConfirmModal } from "../../components/shared/ConfirmModal";
 import { ErrorRecoveryCallout } from "../../components/shared/ErrorRecoveryCallout";
 import { SlideOverPanel } from "../../components/shared/SlideOverPanel";
@@ -16,6 +20,7 @@ import {
   isProjectContextIncomplete,
   type ResourceContextMode,
 } from "../resources/resource-context";
+import { listNativeResourceEntryPoints } from "./native-resource-catalog";
 import { SkillAddForm } from "./SkillAddForm";
 import { SkillCopyForm } from "./SkillCopyForm";
 import { SkillEditForm } from "./SkillEditForm";
@@ -45,6 +50,10 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
     projectRoot,
   });
   const contextHint = buildSkillContextHint(contextMode);
+  const nativeResourceEntryPoints = useMemo(
+    () => (client === null ? [] : listNativeResourceEntryPoints(client)),
+    [client],
+  );
   const activeClient = isProjectContextIncomplete({ mode: contextMode, projectRoot })
     ? null
     : client;
@@ -184,7 +193,7 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
     return (
       <ViewStatePanel
         title="Client Selection Required"
-        message="Select a client to list and mutate skill entries."
+        message="Select a client to list and mutate generic skill library entries."
       />
     );
   }
@@ -193,7 +202,7 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
     return (
       <ViewStatePanel
         title="Project Context Required"
-        message="Apply a project root to prepare project-aware Skills screens."
+        message="Apply a project root to review generic skill libraries alongside native-resource notices."
       />
     );
   }
@@ -204,9 +213,10 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
         <CardHeader className="grid gap-4 p-5">
           <div className="flex items-start justify-between gap-3 max-[720px]:flex-col">
             <div>
-              <CardTitle className="text-[1.35rem] tracking-[-0.012em]">Skills Manager</CardTitle>
+              <CardTitle className="text-[1.35rem] tracking-[-0.012em]">Skill Libraries</CardTitle>
               <p className="mt-1 text-sm text-slate-700">
-                Managing AI Manager personal skills for <strong>{formatClientLabel(client)}</strong>
+                Managing AI Manager generic skill libraries for{" "}
+                <strong>{formatClientLabel(client)}</strong>
               </p>
               <p className="mt-1 text-xs text-slate-500">{contextSummary.description}</p>
             </div>
@@ -224,12 +234,54 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
                 {phase === "loading" ? "Loading..." : "Reload"}
               </Button>
               <Button type="button" size="sm" onClick={openComposer}>
-                Add Personal Skill
+                Add Generic Skill
               </Button>
             </div>
           </div>
 
           {contextMode === "project" ? <Alert variant="warning">{contextHint}</Alert> : null}
+
+          <section className="grid gap-3 rounded-2xl border border-slate-200/90 bg-white/90 p-3.5">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="rounded-full bg-emerald-600 px-3 py-1 text-[0.69rem] font-semibold uppercase tracking-[0.08em] text-white">
+                {RESOURCE_KIND_CATALOG.skill.family} family
+              </p>
+              <p className="rounded-full bg-slate-900 px-3 py-1 text-[0.69rem] font-semibold uppercase tracking-[0.08em] text-slate-100">
+                AI Manager-managed
+              </p>
+            </div>
+            <p className="text-sm text-slate-700">
+              This surface manages reusable `SKILL.md` libraries only. Native client resources stay
+              on dedicated surfaces so project-native features do not get folded into generic skill
+              storage.
+            </p>
+            {nativeResourceEntryPoints.length > 0 ? (
+              <div className="grid gap-2">
+                {nativeResourceEntryPoints.map((entryPoint) => (
+                  <div
+                    key={entryPoint.id}
+                    className="rounded-xl border border-sky-200/80 bg-sky-50/80 p-3"
+                  >
+                    <div className="flex items-start justify-between gap-3 max-[720px]:flex-col">
+                      <div className="grid gap-1">
+                        <p className="text-sm font-semibold text-slate-900">{entryPoint.title}</p>
+                        <p className="text-xs leading-relaxed text-slate-600">
+                          {entryPoint.description}
+                        </p>
+                      </div>
+                      <p className="rounded-full bg-sky-600 px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-white">
+                        {entryPoint.statusLabel}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs text-slate-500">
+                No native resource entry points are defined for this client yet.
+              </p>
+            )}
+          </section>
 
           <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-slate-200/90 bg-white/90 p-2.5">
             <p className="rounded-full bg-slate-900 px-3 py-1 text-[0.69rem] font-semibold uppercase tracking-[0.08em] text-slate-100">
@@ -274,8 +326,8 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
               normalizedQuery.length > 0
                 ? `No skill entries match "${searchQuery.trim()}".`
                 : contextMode === "project"
-                  ? "No personal skill entries are available for the selected client in this project context."
-                  : "No skill entries registered for the selected client."
+                  ? "No generic skill library entries are available for the selected client in this project context."
+                  : "No generic skill library entries are registered for the selected client."
             }
           />
         </CardContent>
@@ -283,8 +335,8 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
 
       <SlideOverPanel
         open={isComposerOpen}
-        title="Add Personal Skill"
-        description="Install a skill into the selected client's personal storage while keeping the list in view."
+        title="Add Generic Skill"
+        description="Install a skill into the selected client's personal library storage while keeping the list in view."
         panelClassName="max-w-[42rem] max-[920px]:max-w-full"
         onClose={() => setComposerOpen(false)}
       >
@@ -311,8 +363,8 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
 
       <SlideOverPanel
         open={isCopyOpen}
-        title="Copy Skill to Another Client"
-        description="Copy the selected skill into another client's personal skill storage."
+        title="Copy Generic Skill to Another Client"
+        description="Copy the selected skill into another client's personal generic skill library."
         panelClassName="max-w-[40rem] max-[920px]:max-w-full"
         onClose={() => {
           if (pendingCopyId !== null) {
@@ -338,8 +390,8 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
 
       <SlideOverPanel
         open={isEditOpen}
-        title="Edit Personal Skill"
-        description="Update the selected skill manifest in the client's personal storage."
+        title="Edit Generic Skill"
+        description="Update the selected skill manifest in the client's personal generic library."
         panelClassName="max-w-[40rem] max-[920px]:max-w-full"
         onClose={() => {
           if (pendingUpdateId !== null) {
@@ -363,7 +415,7 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
 
       <ConfirmModal
         open={removalCandidate !== null}
-        title="Remove Personal Skill"
+        title="Remove Generic Skill"
         description={
           removalCandidate ? (
             <p>
@@ -374,7 +426,7 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
             ""
           )
         }
-        confirmLabel={pendingRemovalId === null ? "Remove from personal" : "Removing..."}
+        confirmLabel={pendingRemovalId === null ? "Remove from library" : "Removing..."}
         confirmDisabled={pendingRemovalId !== null}
         onConfirm={() => {
           void handleConfirmRemoval();

--- a/src/features/skills/native-resource-catalog.ts
+++ b/src/features/skills/native-resource-catalog.ts
@@ -1,0 +1,26 @@
+import type { ClientKind } from "../../backend/contracts";
+
+export interface NativeResourceEntryPoint {
+  id: string;
+  title: string;
+  description: string;
+  statusLabel: string;
+}
+
+const CLAUDE_NATIVE_ENTRY_POINTS: NativeResourceEntryPoint[] = [
+  {
+    id: "claude-subagents",
+    title: "Claude Subagents",
+    description:
+      "Native Claude agent manifests live under ~/.claude/agents and project .claude/agents directories. They stay separate from generic SKILL.md libraries.",
+    statusLabel: "Dedicated surface planned",
+  },
+];
+
+export function listNativeResourceEntryPoints(client: ClientKind): NativeResourceEntryPoint[] {
+  if (client === "claude_code") {
+    return CLAUDE_NATIVE_ENTRY_POINTS;
+  }
+
+  return [];
+}

--- a/src/features/skills/skill-context.ts
+++ b/src/features/skills/skill-context.ts
@@ -2,10 +2,10 @@ import type { ResourceContextMode } from "../resources/resource-context";
 
 export function buildSkillContextHint(contextMode: ResourceContextMode): string {
   if (contextMode === "project") {
-    return "This tab manages AI Manager personal skill libraries only. Claude native project support is tracked separately as subagents and does not appear in this view.";
+    return "This tab manages AI Manager generic skill libraries in personal storage only. Claude native project support is tracked separately as subagents and does not appear in this view.";
   }
 
-  return "This tab manages AI Manager personal skill libraries for the selected client.";
+  return "This tab manages AI Manager generic skill libraries for the selected client.";
 }
 
 export function describeSkillAction(

--- a/tests/skill-context.test.ts
+++ b/tests/skill-context.test.ts
@@ -1,20 +1,22 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { RESOURCE_KIND_CATALOG } from "../src/backend/contracts.ts";
+import { listNativeResourceEntryPoints } from "../src/features/skills/native-resource-catalog.ts";
 import {
   buildSkillContextHint,
   describeSkillAction,
 } from "../src/features/skills/skill-context.ts";
 
 test("project mode hint stays explicit about personal-only skill storage", () => {
-  assert.match(buildSkillContextHint("project"), /personal skill libraries/i);
+  assert.match(buildSkillContextHint("project"), /generic skill libraries/i);
   assert.match(buildSkillContextHint("project"), /subagents/i);
 });
 
 test("personal mode hint stays concise", () => {
   assert.equal(
     buildSkillContextHint("personal"),
-    "This tab manages AI Manager personal skill libraries for the selected client.",
+    "This tab manages AI Manager generic skill libraries for the selected client.",
   );
 });
 
@@ -24,4 +26,20 @@ test("skill action labels stay explicit", () => {
   assert.equal(describeSkillAction("remove"), "Remove from personal");
   assert.equal(describeSkillAction("copy"), "Copy to another client");
   assert.equal(describeSkillAction("import"), "Import to personal skills");
+});
+
+test("resource kind catalog marks generic and native families explicitly", () => {
+  assert.equal(RESOURCE_KIND_CATALOG.skill.family, "generic");
+  assert.equal(RESOURCE_KIND_CATALOG.skill.managementModel, "ai_manager");
+  assert.equal(RESOURCE_KIND_CATALOG.mcp.family, "native");
+  assert.equal(RESOURCE_KIND_CATALOG.subagent.family, "native");
+});
+
+test("native resource entry points preview Claude-only native surfaces", () => {
+  assert.equal(listNativeResourceEntryPoints("claude_code").length, 1);
+  assert.match(
+    listNativeResourceEntryPoints("claude_code")[0].description,
+    /native Claude agent manifests/i,
+  );
+  assert.deepEqual(listNativeResourceEntryPoints("cursor"), []);
 });

--- a/tests/support-matrix.test.mjs
+++ b/tests/support-matrix.test.mjs
@@ -6,6 +6,7 @@ const matrixPath = new URL("../docs/spec/support-matrix.v1.json", import.meta.ur
 const matrix = JSON.parse(readFileSync(matrixPath, "utf8"));
 
 const expectedClientIds = ["claude_code", "codex", "cursor"];
+const resourceFamilySet = new Set(["generic", "native"]);
 const sourceScopeSet = new Set(["user", "project_shared", "project_private"]);
 
 function assertContiguousPriorities(candidates, fieldName) {
@@ -72,6 +73,10 @@ test("resource kinds expose staged scope support and precedence", () => {
       assert.ok(Array.isArray(support.targetDestinationScopes));
       assert.ok(Array.isArray(support.effectivePrecedence));
       assert.ok(Array.isArray(support.notes));
+      assert.ok(
+        resourceFamilySet.has(support.family),
+        `unsupported ${client.id}/${kind} family: ${support.family}`,
+      );
 
       for (const scope of support.targetSourceScopes) {
         assert.ok(sourceScopeSet.has(scope), `unsupported ${client.id}/${kind} scope: ${scope}`);
@@ -120,6 +125,14 @@ test("skills notes distinguish generic repositories from native client features"
   }
 
   assert.match(byId.get("claude_code").resourceKinds.skills.notes.join(" "), /subagents|agents/i);
+});
+
+test("resource families distinguish generic skill libraries from native resources", () => {
+  for (const client of matrix.clients) {
+    assert.equal(client.resourceKinds.skills.family, "generic");
+    assert.equal(client.resourceKinds.mcp.family, "native");
+    assert.equal(client.resourceKinds.subagents.family, "native");
+  }
 });
 
 test("subagents are modeled as a dedicated Claude-native resource kind", () => {


### PR DESCRIPTION
## Summary
- add explicit generic/native family markers to the shared contract and support matrix
- update navigation and Skills panel copy to present generic skill libraries separately from native resources
- add a Claude native-resource preview entry point so future surfaces can land without redefining `skill`

Closes #139