### PR TITLE
feat: align skill library UI with MCP manager

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,11 +30,7 @@ function findSelectedDetection(
   return detections.find((entry) => entry.client === selectedClient) ?? null;
 }
 
-function renderRouteContent(
-  route: AppRoute,
-  selectedDetection: ClientDetection | null,
-  resourceContext: ResourceContextState,
-) {
+function renderRouteContent(route: AppRoute, resourceContext: ResourceContextState) {
   if (route === "dashboard") {
     return null;
   }
@@ -50,7 +46,6 @@ function renderRouteContent(
 
   return (
     <SkillsManagerPanel
-      client={selectedDetection?.client ?? null}
       contextMode={resourceContext.mode}
       projectRoot={resourceContext.projectRoot}
     />
@@ -86,8 +81,8 @@ function App() {
   );
 
   const featureContent = useMemo(
-    () => renderRouteContent(activeRoute, selectedDetection, resourceContext),
-    [activeRoute, resourceContext, selectedDetection],
+    () => renderRouteContent(activeRoute, resourceContext),
+    [activeRoute, resourceContext],
   );
   const isDashboardRoute = activeRoute === "dashboard";
 
@@ -222,37 +217,21 @@ function App() {
               <section className="flex flex-wrap items-end justify-between gap-3 rounded-2xl border border-slate-200 bg-[linear-gradient(180deg,#fbfdff_0%,#f7fafc_100%)] px-4 py-3">
                 <div className="grid gap-1">
                   <p className="text-[0.7rem] font-semibold uppercase tracking-[0.09em] text-slate-500">
-                    Active Client
+                    Skill Library Overview
                   </p>
                   <p className="text-sm text-slate-700">
-                    Manager views prioritize generic skill library operations. Open dashboard for
-                    full tool cards.
+                    Generic skill libraries now span the supported clients inside the selected
+                    context.
                   </p>
                 </div>
-
-                <div className="flex items-center gap-2 max-[720px]:w-full">
-                  <select
-                    className="h-10 min-w-[13.5rem] rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-900 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 max-[720px]:w-full"
-                    value={selectedClient ?? ""}
-                    onChange={(event) =>
-                      setSelectedClient(event.currentTarget.value as ClientDetection["client"])
-                    }
-                  >
-                    {detections.map((detection) => (
-                      <option key={detection.client} value={detection.client}>
-                        {formatClientLabel(detection.client)}
-                      </option>
-                    ))}
-                  </select>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setActiveRoute("dashboard")}
-                  >
-                    Open Dashboard
-                  </Button>
-                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setActiveRoute("dashboard")}
+                >
+                  Open Dashboard
+                </Button>
               </section>
             ) : (
               <section className="flex flex-wrap items-end justify-between gap-3 rounded-2xl border border-slate-200 bg-[linear-gradient(180deg,#fbfdff_0%,#f7fafc_100%)] px-4 py-3">

--- a/src/features/skills/SkillAddForm.tsx
+++ b/src/features/skills/SkillAddForm.tsx
@@ -1,11 +1,14 @@
 import type { FormEvent } from "react";
 
+import type { ClientKind } from "../../backend/contracts";
 import { Alert } from "../../components/ui/alert";
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Textarea } from "../../components/ui/textarea";
 import { cn } from "../../lib/utils";
+import { formatClientLabel } from "../clients/client-labels";
+import { SKILL_CLIENTS } from "./skill-targets";
 import type { SkillAddFormState, SkillAddMode, SkillSyncInfo } from "./useSkillAddForm";
 import type { SkillInstallInputKind } from "./useSkillManager";
 
@@ -13,6 +16,10 @@ interface SkillAddFormProps {
   disabled: boolean;
   state: SkillAddFormState;
   syncInfo: SkillSyncInfo;
+  destinationClient: ClientKind;
+  destinationDescription: string;
+  submitButtonLabel: string;
+  onDestinationClientChange: (value: ClientKind) => void;
   onModeChange: (value: SkillAddMode) => void;
   onTargetIdChange: (value: string) => void;
   onInstallKindChange: (value: SkillInstallInputKind) => void;
@@ -30,6 +37,10 @@ export function SkillAddForm({
   disabled,
   state,
   syncInfo,
+  destinationClient,
+  destinationDescription,
+  submitButtonLabel,
+  onDestinationClientChange,
   onModeChange,
   onTargetIdChange,
   onInstallKindChange,
@@ -50,7 +61,7 @@ export function SkillAddForm({
   const submitDisabled =
     disabled || isUpToDate || (state.mode === "github" && !state.githubRiskAcknowledged);
 
-  function submitLabel(): string {
+  function resolveSubmitLabel(): string {
     if (syncInfo.status === "up_to_date") {
       return "Up to Date";
     }
@@ -66,6 +77,9 @@ export function SkillAddForm({
       onSubmit={(event) => void onSubmit(event)}
     >
       {state.localError ? <Alert variant="destructive">{state.localError}</Alert> : null}
+      <Alert variant="default" className="break-words">
+        {destinationDescription}
+      </Alert>
       {syncInfo.status === "up_to_date" ? (
         <Alert variant="default" className="break-words">
           Skill ID <strong>{state.targetId.trim() || "(empty)"}</strong> is up to date.
@@ -77,6 +91,21 @@ export function SkillAddForm({
           different content. Submitting will update it.
         </Alert>
       ) : null}
+
+      <Label htmlFor="skill-destination-client">Destination Client</Label>
+      <select
+        id="skill-destination-client"
+        className="h-10 w-full min-w-0 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 disabled:cursor-not-allowed disabled:opacity-50"
+        value={destinationClient}
+        onChange={(event) => onDestinationClientChange(event.currentTarget.value as ClientKind)}
+        disabled={disabled}
+      >
+        {SKILL_CLIENTS.map((client) => (
+          <option key={client} value={client}>
+            {formatClientLabel(client)}
+          </option>
+        ))}
+      </select>
 
       <Label>Add Method</Label>
       <div className="grid grid-cols-2 gap-2">
@@ -243,7 +272,7 @@ export function SkillAddForm({
       )}
 
       <Button type="submit" disabled={submitDisabled}>
-        {submitLabel()}
+        {submitButtonLabel || resolveSubmitLabel()}
       </Button>
     </form>
   );

--- a/src/features/skills/SkillCopyForm.tsx
+++ b/src/features/skills/SkillCopyForm.tsx
@@ -8,6 +8,7 @@ import { Label } from "../../components/ui/label";
 import { Textarea } from "../../components/ui/textarea";
 import { cn } from "../../lib/utils";
 import { formatClientLabel } from "../clients/client-labels";
+import { buildSkillCopyDestinationClients } from "./skill-targets";
 import type { SkillCopyFormState } from "./useSkillCopyForm";
 import type { SkillInstallInputKind } from "./useSkillManager";
 
@@ -21,8 +22,6 @@ interface SkillCopyFormProps {
   className?: string;
 }
 
-const CLIENTS: ClientKind[] = ["codex", "claude_code", "cursor"];
-
 export function SkillCopyForm({
   disabled,
   state,
@@ -32,7 +31,7 @@ export function SkillCopyForm({
   onSubmit,
   className,
 }: SkillCopyFormProps) {
-  const destinationOptions = CLIENTS.filter((client) => client !== state.sourceClient);
+  const destinationOptions = buildSkillCopyDestinationClients(state.sourceClient);
 
   return (
     <form

--- a/src/features/skills/SkillEditForm.tsx
+++ b/src/features/skills/SkillEditForm.tsx
@@ -6,6 +6,7 @@ import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Textarea } from "../../components/ui/textarea";
 import { cn } from "../../lib/utils";
+import { formatClientLabel } from "../clients/client-labels";
 import type { SkillEditFormState } from "./useSkillEditForm";
 
 interface SkillEditFormProps {
@@ -29,6 +30,9 @@ export function SkillEditForm({
       onSubmit={(event) => void onSubmit(event)}
     >
       {state.localError ? <Alert variant="destructive">{state.localError}</Alert> : null}
+
+      <Label htmlFor="skill-edit-client">Client</Label>
+      <Input id="skill-edit-client" value={formatClientLabel(state.client)} disabled />
 
       <Label htmlFor="skill-edit-target-id">Target ID</Label>
       <Input id="skill-edit-target-id" value={state.targetId} disabled />

--- a/src/features/skills/SkillResourceTable.tsx
+++ b/src/features/skills/SkillResourceTable.tsx
@@ -10,6 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from "../../components/ui/table";
+import { formatClientLabel } from "../clients/client-labels";
 
 interface SkillResourceTableProps {
   resources: ResourceRecord[];
@@ -20,10 +21,6 @@ interface SkillResourceTableProps {
   onCopy: (resource: ResourceRecord) => Promise<void>;
   onRemove: (resource: ResourceRecord) => Promise<void>;
   emptyMessage?: string;
-}
-
-function formatSourcePath(sourcePath: string | null): string {
-  return sourcePath ?? "Auto-resolved";
 }
 
 function formatInstallKind(value: string | null): string {
@@ -113,6 +110,21 @@ function SkillActionButton({
   );
 }
 
+function StatusBadge({ tone, label }: { tone: "neutral" | "success"; label: string }) {
+  const className =
+    tone === "success"
+      ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+      : "border-slate-200 bg-slate-100 text-slate-700";
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[0.68rem] font-semibold uppercase tracking-[0.08em] ${className}`}
+    >
+      {label}
+    </span>
+  );
+}
+
 export function SkillResourceTable({
   resources,
   pendingRemovalId,
@@ -127,7 +139,7 @@ export function SkillResourceTable({
     return (
       <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50/70 px-4 py-7 text-center">
         <p className="text-sm leading-relaxed text-slate-600">
-          {emptyMessage ?? "No skill entries registered for the selected client."}
+          {emptyMessage ?? "No generic skill entries registered for the current context."}
         </p>
       </div>
     );
@@ -135,69 +147,106 @@ export function SkillResourceTable({
 
   return (
     <div className="overflow-auto rounded-2xl border border-slate-200/90 bg-white">
-      <Table className="min-w-[42rem] max-[720px]:min-w-[36rem]">
+      <Table className="min-w-[62rem] max-[720px]:min-w-[48rem]">
         <TableHeader>
           <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead>Install Kind</TableHead>
-            <TableHead>Enabled</TableHead>
+            <TableHead>Client</TableHead>
+            <TableHead>Skill Entry</TableHead>
+            <TableHead>Install</TableHead>
+            <TableHead>Status</TableHead>
             <TableHead>Source</TableHead>
-            <TableHead aria-label="actions" className="w-[17rem]" />
+            <TableHead aria-label="actions" className="w-40" />
           </TableRow>
         </TableHeader>
         <TableBody>
           {resources.map((resource) => {
-            const removing = pendingRemovalId === resource.display_name;
-            const updating = pendingUpdateId === resource.display_name;
+            const removing = pendingRemovalId === resource.id;
+            const updating = pendingUpdateId === resource.id;
             const copying = pendingCopyId === resource.id;
-            const sourceText = formatSourcePath(resource.source_path);
+            const sourceText = resource.source_path ?? "Auto-resolved";
+
             return (
               <TableRow key={resource.id} className="hover:bg-slate-50/70">
-                <TableCell
-                  className="max-w-[12rem] truncate font-medium text-slate-900"
-                  title={resource.display_name}
-                >
-                  {resource.display_name}
+                <TableCell>
+                  <div className="grid gap-1">
+                    <span className="text-sm font-medium text-slate-900">
+                      {formatClientLabel(resource.client)}
+                    </span>
+                    <span className="text-xs text-slate-500">{resource.client}</span>
+                  </div>
                 </TableCell>
-                <TableCell>{formatInstallKind(resource.install_kind)}</TableCell>
-                <TableCell>{resource.enabled ? "yes" : "no"}</TableCell>
-                <TableCell className="max-w-[18rem] truncate" title={sourceText}>
-                  {sourceText}
+                <TableCell>
+                  <div className="grid gap-1">
+                    <span className="font-medium text-slate-900">{resource.display_name}</span>
+                    <span className="text-xs text-slate-500">{resource.logical_id}</span>
+                  </div>
                 </TableCell>
-                <TableCell className="flex items-center justify-end gap-1.5 whitespace-nowrap">
-                  <SkillActionButton
-                    icon={<CopyIcon />}
-                    label="Copy to another client"
-                    busyLabel="Copying..."
-                    busy={copying}
-                    disabled={copying || updating || removing}
-                    className="h-8 w-8 rounded-lg border border-sky-200 bg-sky-50 p-0 text-sky-700 hover:bg-sky-100 hover:text-sky-800"
-                    onClick={() => {
-                      void onCopy(resource);
-                    }}
-                  />
-                  <SkillActionButton
-                    icon={<EditIcon />}
-                    label="Edit personal skill"
-                    busyLabel="Updating..."
-                    busy={updating}
-                    disabled={updating || removing || copying}
-                    className="h-8 w-8 rounded-lg border border-amber-200 bg-amber-50 p-0 text-amber-800 hover:bg-amber-100 hover:text-amber-900"
-                    onClick={() => {
-                      void onEdit(resource);
-                    }}
-                  />
-                  <SkillActionButton
-                    icon={<RemoveIcon />}
-                    label="Remove from personal"
-                    busyLabel="Removing..."
-                    busy={removing}
-                    disabled={removing || updating || copying}
-                    className="h-8 w-8 rounded-lg border border-rose-200 bg-rose-50 p-0 text-rose-700 hover:bg-rose-100 hover:text-rose-800"
-                    onClick={() => {
-                      void onRemove(resource);
-                    }}
-                  />
+                <TableCell>
+                  <div className="grid gap-1">
+                    <span className="text-sm text-slate-900">
+                      {formatInstallKind(resource.install_kind)}
+                    </span>
+                    <span className="text-xs text-slate-500">Generic skill library</span>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-wrap gap-1.5">
+                    <StatusBadge
+                      tone={resource.enabled ? "success" : "neutral"}
+                      label={resource.enabled ? "Enabled" : "Disabled"}
+                    />
+                    <StatusBadge tone="neutral" label="Personal" />
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="grid gap-1">
+                    <span className="text-sm font-medium text-slate-900">
+                      {resource.source_label}
+                    </span>
+                    <span className="text-xs uppercase tracking-[0.08em] text-slate-500">
+                      {resource.source_scope.replace("_", " ")}
+                    </span>
+                    <span className="truncate text-xs text-slate-500" title={sourceText}>
+                      {sourceText}
+                    </span>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <SkillActionButton
+                      icon={<CopyIcon />}
+                      label="Copy to another client"
+                      busyLabel="Copying..."
+                      busy={copying}
+                      disabled={copying || updating || removing}
+                      className="h-8 w-8 rounded-lg border border-sky-200 bg-sky-50 p-0 text-sky-700 hover:bg-sky-100 hover:text-sky-800"
+                      onClick={() => {
+                        void onCopy(resource);
+                      }}
+                    />
+                    <SkillActionButton
+                      icon={<EditIcon />}
+                      label={`Edit in ${formatClientLabel(resource.client)}`}
+                      busyLabel="Updating..."
+                      busy={updating}
+                      disabled={updating || removing || copying}
+                      className="h-8 w-8 rounded-lg border border-amber-200 bg-amber-50 p-0 text-amber-800 hover:bg-amber-100 hover:text-amber-900"
+                      onClick={() => {
+                        void onEdit(resource);
+                      }}
+                    />
+                    <SkillActionButton
+                      icon={<RemoveIcon />}
+                      label={`Remove from ${formatClientLabel(resource.client)}`}
+                      busyLabel="Removing..."
+                      busy={removing}
+                      disabled={removing || updating || copying}
+                      className="h-8 w-8 rounded-lg border border-rose-200 bg-rose-50 p-0 text-rose-700 hover:bg-rose-100 hover:text-rose-800"
+                      onClick={() => {
+                        void onRemove(resource);
+                      }}
+                    />
+                  </div>
                 </TableCell>
               </TableRow>
             );

--- a/src/features/skills/SkillsManagerPanel.tsx
+++ b/src/features/skills/SkillsManagerPanel.tsx
@@ -1,10 +1,6 @@
 import { useMemo, useState } from "react";
 
-import {
-  type ClientKind,
-  RESOURCE_KIND_CATALOG,
-  type ResourceRecord,
-} from "../../backend/contracts";
+import { RESOURCE_KIND_CATALOG, type ResourceRecord } from "../../backend/contracts";
 import { ConfirmModal } from "../../components/shared/ConfirmModal";
 import { ErrorRecoveryCallout } from "../../components/shared/ErrorRecoveryCallout";
 import { SlideOverPanel } from "../../components/shared/SlideOverPanel";
@@ -17,7 +13,6 @@ import { Input } from "../../components/ui/input";
 import { formatClientLabel } from "../clients/client-labels";
 import {
   buildResourceContextSummary,
-  isProjectContextIncomplete,
   type ResourceContextMode,
 } from "../resources/resource-context";
 import { listNativeResourceEntryPoints } from "./native-resource-catalog";
@@ -28,35 +23,38 @@ import { SkillResourceTable } from "./SkillResourceTable";
 import { buildResourceSkillManifestChecksum } from "./skill-checksum";
 import { buildSkillContextHint } from "./skill-context";
 import { buildSkillGithubRecentsStorageKey } from "./skill-github-recents";
+import {
+  countSkillResourcesByClient,
+  filterSkillResources,
+  toggleSkillClientFilter,
+} from "./skill-list-view";
+import {
+  buildSkillDestinationDescription,
+  describeSkillAction,
+  SKILL_CLIENTS,
+} from "./skill-targets";
 import { useSkillAddForm } from "./useSkillAddForm";
 import { useSkillCopyForm } from "./useSkillCopyForm";
 import { useSkillEditForm } from "./useSkillEditForm";
 import { useSkillManager } from "./useSkillManager";
 
 interface SkillsManagerPanelProps {
-  client: ClientKind | null;
   contextMode: ResourceContextMode;
   projectRoot: string | null;
 }
 
-export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsManagerPanelProps) {
+export function SkillsManagerPanel({ contextMode, projectRoot }: SkillsManagerPanelProps) {
   const [isComposerOpen, setComposerOpen] = useState(false);
   const [isCopyOpen, setCopyOpen] = useState(false);
   const [isEditOpen, setEditOpen] = useState(false);
   const [removalCandidate, setRemovalCandidate] = useState<ResourceRecord | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const [clientFilters, setClientFilters] = useState(SKILL_CLIENTS);
   const contextSummary = buildResourceContextSummary({
     mode: contextMode,
     projectRoot,
   });
   const contextHint = buildSkillContextHint(contextMode);
-  const nativeResourceEntryPoints = useMemo(
-    () => (client === null ? [] : listNativeResourceEntryPoints(client)),
-    [client],
-  );
-  const activeClient = isProjectContextIncomplete({ mode: contextMode, projectRoot })
-    ? null
-    : client;
 
   const {
     phase,
@@ -74,7 +72,7 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
     removeSkill,
     refresh,
     clearFeedback,
-  } = useSkillManager(activeClient);
+  } = useSkillManager();
 
   const existingSkillsById = useMemo(() => {
     const entries = new Map<
@@ -90,7 +88,8 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
       if (normalizedTargetId.length === 0) {
         continue;
       }
-      entries.set(normalizedTargetId, {
+
+      entries.set(`${resource.client}::${normalizedTargetId}`, {
         installKind: resource.install_kind === "file" ? "file" : "directory",
         checksum: buildResourceSkillManifestChecksum(resource),
       });
@@ -104,7 +103,7 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
     onUpdateSubmit: updateSkill,
     onDiscoverGithubRepo: discoverGithubSkills,
     existingSkillsById,
-    recentGithubRepoStorageKey: client ? buildSkillGithubRecentsStorageKey(client) : undefined,
+    getRecentGithubRepoStorageKey: buildSkillGithubRecentsStorageKey,
     onAccepted: () => setComposerOpen(false),
   });
   const editForm = useSkillEditForm({
@@ -116,41 +115,56 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
     onAccepted: () => setCopyOpen(false),
   });
 
+  const primaryAddLabel = useMemo(() => {
+    if (clientFilters.length !== 1) {
+      return "Choose add destination";
+    }
+
+    return describeSkillAction("add", clientFilters[0]);
+  }, [clientFilters]);
+  const addSubmitLabel = useMemo(() => {
+    if (addForm.syncInfo.status === "update_available") {
+      return describeSkillAction("update", addForm.state.destinationClient);
+    }
+
+    return describeSkillAction(
+      addForm.state.mode === "manual" ? "add" : "import",
+      addForm.state.destinationClient,
+    );
+  }, [addForm.state.destinationClient, addForm.state.mode, addForm.syncInfo.status]);
+  const clientCounts = useMemo(() => countSkillResourcesByClient(resources), [resources]);
+  const filteredResources = useMemo(
+    () => filterSkillResources(resources, clientFilters, searchQuery),
+    [clientFilters, resources, searchQuery],
+  );
+  const nativeResourceEntryPoints = useMemo(
+    () =>
+      clientFilters.flatMap((client) =>
+        listNativeResourceEntryPoints(client).map((entryPoint) => ({
+          ...entryPoint,
+          client,
+        })),
+      ),
+    [clientFilters],
+  );
   const normalizedQuery = searchQuery.trim().toLowerCase();
   const snackbarFeedback = useMemo(() => {
     if (feedback === null) {
       return null;
     }
+
     if (feedback.kind === "error" && feedback.diagnostic) {
       return {
         tone: "error" as const,
         message: `CODE: ${feedback.diagnostic.code} | ${feedback.message}`,
       };
     }
+
     return {
       tone: feedback.kind === "error" ? ("error" as const) : ("success" as const),
       message: feedback.message,
     };
   }, [feedback]);
-  const filteredResources = useMemo(() => {
-    if (normalizedQuery.length === 0) {
-      return resources;
-    }
-
-    return resources.filter((resource) => {
-      const haystack = [
-        resource.display_name,
-        resource.install_kind,
-        resource.source_path,
-        resource.id,
-      ]
-        .filter((value): value is string => value !== null && value !== undefined)
-        .join(" ")
-        .toLowerCase();
-
-      return haystack.includes(normalizedQuery);
-    });
-  }, [normalizedQuery, resources]);
 
   async function handleRemove(resource: ResourceRecord) {
     setRemovalCandidate(resource);
@@ -173,7 +187,12 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
       return;
     }
 
-    await removeSkill(removalCandidate.display_name, removalCandidate.source_path);
+    await removeSkill({
+      resourceId: removalCandidate.id,
+      client: removalCandidate.client,
+      targetId: removalCandidate.display_name,
+      sourcePath: removalCandidate.source_path,
+    });
     setRemovalCandidate(null);
   }
 
@@ -181,28 +200,23 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
     if (pendingRemovalId !== null) {
       return;
     }
+
     setRemovalCandidate(null);
   }
 
   function openComposer() {
     clearFeedback();
+    if (clientFilters.length === 1) {
+      addForm.setDestinationClient(clientFilters[0]);
+    }
     setComposerOpen(true);
-  }
-
-  if (client === null) {
-    return (
-      <ViewStatePanel
-        title="Client Selection Required"
-        message="Select a client to list and mutate generic skill library entries."
-      />
-    );
   }
 
   if (contextMode === "project" && projectRoot === null) {
     return (
       <ViewStatePanel
         title="Project Context Required"
-        message="Apply a project root to review generic skill libraries alongside native-resource notices."
+        message="Apply a project root to review generic skill libraries in project mode."
       />
     );
   }
@@ -214,11 +228,11 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
           <div className="flex items-start justify-between gap-3 max-[720px]:flex-col">
             <div>
               <CardTitle className="text-[1.35rem] tracking-[-0.012em]">Skill Libraries</CardTitle>
-              <p className="mt-1 text-sm text-slate-700">
-                Managing AI Manager generic skill libraries for{" "}
-                <strong>{formatClientLabel(client)}</strong>
+              <p className="mt-1 text-sm text-slate-700">{contextSummary.description}</p>
+              <p className="mt-1 text-xs text-slate-500">
+                Generic skill libraries across {clientFilters.length} client filter
+                {clientFilters.length === 1 ? "" : "s"}.
               </p>
-              <p className="mt-1 text-xs text-slate-500">{contextSummary.description}</p>
             </div>
             <div className="flex items-center gap-2">
               <Button
@@ -234,12 +248,12 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
                 {phase === "loading" ? "Loading..." : "Reload"}
               </Button>
               <Button type="button" size="sm" onClick={openComposer}>
-                Add Generic Skill
+                {primaryAddLabel}
               </Button>
             </div>
           </div>
 
-          {contextMode === "project" ? <Alert variant="warning">{contextHint}</Alert> : null}
+          {contextMode === "project" ? <Alert variant="default">{contextHint}</Alert> : null}
 
           <section className="grid gap-3 rounded-2xl border border-slate-200/90 bg-white/90 p-3.5">
             <div className="flex flex-wrap items-center gap-2">
@@ -259,12 +273,17 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
               <div className="grid gap-2">
                 {nativeResourceEntryPoints.map((entryPoint) => (
                   <div
-                    key={entryPoint.id}
+                    key={`${entryPoint.client}:${entryPoint.id}`}
                     className="rounded-xl border border-sky-200/80 bg-sky-50/80 p-3"
                   >
                     <div className="flex items-start justify-between gap-3 max-[720px]:flex-col">
                       <div className="grid gap-1">
-                        <p className="text-sm font-semibold text-slate-900">{entryPoint.title}</p>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="text-sm font-semibold text-slate-900">{entryPoint.title}</p>
+                          <span className="rounded-full bg-white px-2 py-0.5 text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-slate-600">
+                            {formatClientLabel(entryPoint.client)}
+                          </span>
+                        </div>
                         <p className="text-xs leading-relaxed text-slate-600">
                           {entryPoint.description}
                         </p>
@@ -278,26 +297,55 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
               </div>
             ) : (
               <p className="text-xs text-slate-500">
-                No native resource entry points are defined for this client yet.
+                No native resource entry points are defined for the active client filters yet.
               </p>
             )}
           </section>
 
-          <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-slate-200/90 bg-white/90 p-2.5">
-            <p className="rounded-full bg-slate-900 px-3 py-1 text-[0.69rem] font-semibold uppercase tracking-[0.08em] text-slate-100">
-              {resources.length} entries
-            </p>
-            <Input
-              value={searchQuery}
-              onChange={(event) => setSearchQuery(event.currentTarget.value)}
-              className="h-9 max-w-[19rem] border-slate-200 bg-white max-[720px]:max-w-full"
-              placeholder="Search name, install kind, source path"
-            />
-            {normalizedQuery.length > 0 ? (
-              <Button type="button" variant="ghost" size="sm" onClick={() => setSearchQuery("")}>
-                Clear
+          <div className="grid gap-3 rounded-2xl border border-slate-200/90 bg-white/90 p-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="rounded-full bg-slate-900 px-3 py-1 text-[0.69rem] font-semibold uppercase tracking-[0.08em] text-slate-100">
+                {filteredResources.length} shown / {resources.length} total
+              </p>
+              <Input
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.currentTarget.value)}
+                className="h-9 max-w-[19rem] border-slate-200 bg-white max-[720px]:max-w-full"
+                placeholder="Search name, client, install kind"
+              />
+              {normalizedQuery.length > 0 ? (
+                <Button type="button" variant="ghost" size="sm" onClick={() => setSearchQuery("")}>
+                  Clear
+                </Button>
+              ) : null}
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant={clientFilters.length === SKILL_CLIENTS.length ? "default" : "outline"}
+                size="sm"
+                onClick={() => setClientFilters(SKILL_CLIENTS)}
+              >
+                All Clients
               </Button>
-            ) : null}
+              {SKILL_CLIENTS.map((client) => {
+                const active = clientFilters.includes(client);
+                return (
+                  <Button
+                    key={client}
+                    type="button"
+                    variant={active ? "secondary" : "outline"}
+                    size="sm"
+                    onClick={() =>
+                      setClientFilters((current) => toggleSkillClientFilter(current, client))
+                    }
+                  >
+                    {formatClientLabel(client)} ({clientCounts.get(client) ?? 0})
+                  </Button>
+                );
+              })}
+            </div>
           </div>
         </CardHeader>
 
@@ -305,7 +353,7 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
           {warning ? <Alert variant="warning">{warning}</Alert> : null}
           {operationError ? (
             <ErrorRecoveryCallout
-              title="Skills list operation failed"
+              title="Skill list operation failed"
               diagnostic={operationError}
               retryLabel="Retry List"
               onRetry={() => {
@@ -325,9 +373,7 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
             emptyMessage={
               normalizedQuery.length > 0
                 ? `No skill entries match "${searchQuery.trim()}".`
-                : contextMode === "project"
-                  ? "No generic skill library entries are available for the selected client in this project context."
-                  : "No generic skill library entries are registered for the selected client."
+                : "No generic skill entries are registered for the current context."
             }
           />
         </CardContent>
@@ -336,7 +382,7 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
       <SlideOverPanel
         open={isComposerOpen}
         title="Add Generic Skill"
-        description="Install a skill into the selected client's personal library storage while keeping the list in view."
+        description="Choose the destination client explicitly, then install the generic skill into that personal library while keeping the list in view."
         panelClassName="max-w-[42rem] max-[920px]:max-w-full"
         onClose={() => setComposerOpen(false)}
       >
@@ -346,6 +392,12 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
             disabled={phase === "loading"}
             state={addForm.state}
             syncInfo={addForm.syncInfo}
+            destinationClient={addForm.state.destinationClient}
+            destinationDescription={buildSkillDestinationDescription(
+              addForm.state.destinationClient,
+            )}
+            submitButtonLabel={addSubmitLabel}
+            onDestinationClientChange={addForm.setDestinationClient}
             onModeChange={addForm.setMode}
             onTargetIdChange={addForm.setTargetId}
             onInstallKindChange={addForm.setInstallKind}
@@ -391,7 +443,7 @@ export function SkillsManagerPanel({ client, contextMode, projectRoot }: SkillsM
       <SlideOverPanel
         open={isEditOpen}
         title="Edit Generic Skill"
-        description="Update the selected skill manifest in the client's personal generic library."
+        description="Update the selected skill manifest in its personal generic library."
         panelClassName="max-w-[40rem] max-[920px]:max-w-full"
         onClose={() => {
           if (pendingUpdateId !== null) {

--- a/src/features/skills/skill-context.ts
+++ b/src/features/skills/skill-context.ts
@@ -5,22 +5,5 @@ export function buildSkillContextHint(contextMode: ResourceContextMode): string 
     return "This tab manages AI Manager generic skill libraries in personal storage only. Claude native project support is tracked separately as subagents and does not appear in this view.";
   }
 
-  return "This tab manages AI Manager generic skill libraries for the selected client.";
-}
-
-export function describeSkillAction(
-  action: "add" | "update" | "remove" | "copy" | "import",
-): string {
-  switch (action) {
-    case "add":
-      return "Add personal skill";
-    case "update":
-      return "Update personal skill";
-    case "remove":
-      return "Remove from personal";
-    case "copy":
-      return "Copy to another client";
-    case "import":
-      return "Import to personal skills";
-  }
+  return "This tab manages AI Manager generic skill libraries across the supported clients.";
 }

--- a/src/features/skills/skill-list-view.ts
+++ b/src/features/skills/skill-list-view.ts
@@ -1,0 +1,65 @@
+import type { ClientKind, ResourceRecord } from "../../backend/contracts";
+import { formatClientLabel } from "../clients/client-labels";
+import { SKILL_CLIENTS } from "./skill-targets";
+
+export function sortSkillResources(resources: ResourceRecord[]): ResourceRecord[] {
+  return [...resources].sort((left, right) => {
+    if (left.display_name !== right.display_name) {
+      return left.display_name.localeCompare(right.display_name);
+    }
+
+    return left.id.localeCompare(right.id);
+  });
+}
+
+export function toggleSkillClientFilter(current: ClientKind[], client: ClientKind): ClientKind[] {
+  if (current.includes(client)) {
+    return current.length === 1 ? current : current.filter((entry) => entry !== client);
+  }
+
+  return [...current, client];
+}
+
+export function countSkillResourcesByClient(resources: ResourceRecord[]): Map<ClientKind, number> {
+  const counts = new Map<ClientKind, number>(SKILL_CLIENTS.map((client) => [client, 0]));
+
+  for (const resource of resources) {
+    counts.set(resource.client, (counts.get(resource.client) ?? 0) + 1);
+  }
+
+  return counts;
+}
+
+export function filterSkillResources(
+  resources: ResourceRecord[],
+  clientFilters: ClientKind[],
+  searchQuery: string,
+): ResourceRecord[] {
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+
+  return sortSkillResources(
+    resources.filter((resource) => {
+      if (!clientFilters.includes(resource.client)) {
+        return false;
+      }
+
+      if (normalizedQuery.length === 0) {
+        return true;
+      }
+
+      const haystack = [
+        formatClientLabel(resource.client),
+        resource.display_name,
+        resource.install_kind,
+        resource.source_label,
+        resource.source_path,
+        resource.id,
+      ]
+        .filter((value): value is string => value !== null && value !== undefined)
+        .join(" ")
+        .toLowerCase();
+
+      return haystack.includes(normalizedQuery);
+    }),
+  );
+}

--- a/src/features/skills/skill-targets.ts
+++ b/src/features/skills/skill-targets.ts
@@ -1,0 +1,34 @@
+import type { ClientKind } from "../../backend/contracts";
+import { formatClientLabel } from "../clients/client-labels";
+
+export const SKILL_CLIENTS: ClientKind[] = ["claude_code", "cursor", "codex"];
+
+export function buildSkillCopyDestinationClients(sourceClient: ClientKind): ClientKind[] {
+  return SKILL_CLIENTS.filter((client) => client !== sourceClient);
+}
+
+export function buildSkillDestinationDescription(client: ClientKind): string {
+  return `${formatClientLabel(client)} stores generic skills in its personal AI Manager skill library.`;
+}
+
+export function describeSkillAction(
+  action: "add" | "update" | "remove" | "copy" | "import",
+  client?: ClientKind,
+): string {
+  const clientLabel = client ? formatClientLabel(client) : null;
+
+  switch (action) {
+    case "add":
+      return clientLabel ? `Add to ${clientLabel} personal library` : "Add personal skill";
+    case "update":
+      return clientLabel ? `Update ${clientLabel} personal skill` : "Update personal skill";
+    case "remove":
+      return clientLabel ? `Remove from ${clientLabel} personal library` : "Remove from personal";
+    case "copy":
+      return "Copy to another client";
+    case "import":
+      return clientLabel
+        ? `Import to ${clientLabel} personal library`
+        : "Import to personal skills";
+  }
+}

--- a/src/features/skills/useSkillAddForm.ts
+++ b/src/features/skills/useSkillAddForm.ts
@@ -1,8 +1,9 @@
 import { type FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 
-import type { DiscoveredSkillCandidate } from "../../backend/contracts";
+import type { ClientKind, DiscoveredSkillCandidate } from "../../backend/contracts";
 import { buildSkillManifestChecksum } from "./skill-checksum";
 import { loadSkillGithubRecents, rememberSkillGithubRepoUrl } from "./skill-github-recents";
+import { SKILL_CLIENTS } from "./skill-targets";
 import type {
   AddSkillInput,
   GithubSkillDiscoveryResult,
@@ -25,6 +26,7 @@ export interface SkillSyncInfo {
 }
 
 export interface SkillAddFormState {
+  destinationClient: ClientKind;
   mode: SkillAddMode;
   targetId: string;
   installKind: SkillInstallInputKind;
@@ -45,12 +47,13 @@ interface UseSkillAddFormParams {
   onDiscoverGithubRepo: (githubRepoUrl: string) => Promise<GithubSkillDiscoveryResult | null>;
   onAccepted?: () => void;
   existingSkillsById?: ReadonlyMap<string, ExistingSkillRecord>;
-  recentGithubRepoStorageKey?: string;
+  getRecentGithubRepoStorageKey?: (client: ClientKind) => string;
 }
 
 interface UseSkillAddFormResult {
   state: SkillAddFormState;
   syncInfo: SkillSyncInfo;
+  setDestinationClient: (value: ClientKind) => void;
   setMode: (value: SkillAddMode) => void;
   setTargetId: (value: string) => void;
   setInstallKind: (value: SkillInstallInputKind) => void;
@@ -69,6 +72,7 @@ Describe what this skill does and how to use it.
 `;
 
 const DEFAULT_STATE: SkillAddFormState = {
+  destinationClient: SKILL_CLIENTS[0],
   mode: "manual",
   targetId: "new-skill",
   installKind: "directory",
@@ -114,7 +118,7 @@ function resolveSyncInfo(
     return { status: "new", existingInstallKind: null };
   }
 
-  const existing = existingSkillsById.get(normalizedTargetId);
+  const existing = existingSkillsById.get(`${state.destinationClient}::${normalizedTargetId}`);
   if (!existing) {
     return { status: "new", existingInstallKind: null };
   }
@@ -137,9 +141,10 @@ export function useSkillAddForm({
   onDiscoverGithubRepo,
   onAccepted,
   existingSkillsById,
-  recentGithubRepoStorageKey,
+  getRecentGithubRepoStorageKey,
 }: UseSkillAddFormParams): UseSkillAddFormResult {
   const [state, setState] = useState<SkillAddFormState>(DEFAULT_STATE);
+  const recentGithubRepoStorageKey = getRecentGithubRepoStorageKey?.(state.destinationClient);
   const syncInfo = useMemo(
     () => resolveSyncInfo(state, existingSkillsById),
     [existingSkillsById, state],
@@ -167,6 +172,10 @@ export function useSkillAddForm({
 
   const setMode = useCallback((value: SkillAddMode) => {
     setState((current) => ({ ...current, mode: value, localError: null }));
+  }, []);
+
+  const setDestinationClient = useCallback((value: ClientKind) => {
+    setState((current) => ({ ...current, destinationClient: value, localError: null }));
   }, []);
 
   const setTargetId = useCallback((value: string) => {
@@ -286,12 +295,15 @@ export function useSkillAddForm({
               }
               return currentSyncInfo.status === "update_available"
                 ? onUpdateSubmit({
+                    client: state.destinationClient,
+                    resourceId: `${state.destinationClient}::${normalizedTargetId}`,
                     mode: "manual",
                     targetId: normalizedTargetId,
                     manifest: state.manifest,
                     installKind: currentSyncInfo.existingInstallKind ?? state.installKind,
                   })
                 : onAddSubmit({
+                    destinationClient: state.destinationClient,
                     mode: "manual",
                     targetId: normalizedTargetId,
                     manifest: state.manifest,
@@ -323,6 +335,8 @@ export function useSkillAddForm({
               }
               return currentSyncInfo.status === "update_available"
                 ? onUpdateSubmit({
+                    client: state.destinationClient,
+                    resourceId: `${state.destinationClient}::${normalizedTargetId}`,
                     mode: "github",
                     targetId: normalizedTargetId,
                     githubRepoUrl: normalizedGithubRepoUrl,
@@ -330,6 +344,7 @@ export function useSkillAddForm({
                     installKind: currentSyncInfo.existingInstallKind ?? "directory",
                   })
                 : onAddSubmit({
+                    destinationClient: state.destinationClient,
                     mode: "github",
                     targetId: normalizedTargetId,
                     githubRepoUrl: normalizedGithubRepoUrl,
@@ -352,6 +367,7 @@ export function useSkillAddForm({
   return {
     state,
     syncInfo,
+    setDestinationClient,
     setMode,
     setTargetId,
     setInstallKind,

--- a/src/features/skills/useSkillCopyForm.ts
+++ b/src/features/skills/useSkillCopyForm.ts
@@ -1,6 +1,7 @@
 import { type FormEvent, useCallback, useState } from "react";
 
 import type { ClientKind, ResourceRecord } from "../../backend/contracts";
+import { buildSkillCopyDestinationClients } from "./skill-targets";
 import type { CopySkillInput, SkillInstallInputKind } from "./useSkillManager";
 
 export interface SkillCopyFormState {
@@ -29,10 +30,8 @@ interface UseSkillCopyFormResult {
   submit: (event: FormEvent<HTMLFormElement>) => Promise<void>;
 }
 
-const CLIENTS: ClientKind[] = ["codex", "claude_code", "cursor"];
-
 function pickDefaultDestination(sourceClient: ClientKind): ClientKind {
-  return CLIENTS.find((candidate) => candidate !== sourceClient) ?? sourceClient;
+  return buildSkillCopyDestinationClients(sourceClient)[0] ?? sourceClient;
 }
 
 const DEFAULT_STATE: SkillCopyFormState = {

--- a/src/features/skills/useSkillEditForm.ts
+++ b/src/features/skills/useSkillEditForm.ts
@@ -1,9 +1,10 @@
 import { type FormEvent, useCallback, useState } from "react";
-
-import type { ResourceRecord } from "../../backend/contracts";
+import type { ClientKind, ResourceRecord } from "../../backend/contracts";
 import type { SkillInstallInputKind, UpdateSkillInput } from "./useSkillManager";
 
 export interface SkillEditFormState {
+  resourceId: string;
+  client: ClientKind;
   targetId: string;
   installKind: SkillInstallInputKind;
   manifest: string;
@@ -29,6 +30,8 @@ Describe what changed in this skill.
 `;
 
 const DEFAULT_STATE: SkillEditFormState = {
+  resourceId: "",
+  client: "claude_code",
   targetId: "",
   installKind: "directory",
   manifest: DEFAULT_MANIFEST,
@@ -46,6 +49,8 @@ export function useSkillEditForm({
       resource.install_kind === "file" ? "file" : "directory";
 
     setState({
+      resourceId: resource.id,
+      client: resource.client,
       targetId: resource.display_name,
       installKind,
       manifest:
@@ -81,6 +86,8 @@ export function useSkillEditForm({
       }
 
       const accepted = await onSubmit({
+        client: state.client,
+        resourceId: state.resourceId,
         mode: "manual",
         targetId: normalizedTargetId,
         installKind: state.installKind,

--- a/src/features/skills/useSkillManager.ts
+++ b/src/features/skills/useSkillManager.ts
@@ -8,22 +8,27 @@ import type {
   ResourceRecord,
 } from "../../backend/contracts";
 import { redactNullableSensitiveText, redactSensitiveText } from "../../security/redaction";
+import { formatClientLabel } from "../clients/client-labels";
 import {
   commandErrorToDiagnostic,
   type ErrorDiagnostic,
   runtimeErrorToDiagnostic,
 } from "../common/errorDiagnostics";
+import { sortSkillResources } from "./skill-list-view";
+import { SKILL_CLIENTS } from "./skill-targets";
 
 export type SkillInstallInputKind = "directory" | "file";
 
 export type AddSkillInput =
   | {
+      destinationClient: ClientKind;
       mode: "manual";
       targetId: string;
       manifest: string;
       installKind: SkillInstallInputKind;
     }
   | {
+      destinationClient: ClientKind;
       mode: "github";
       targetId: string;
       githubRepoUrl: string;
@@ -32,12 +37,16 @@ export type AddSkillInput =
 
 export type UpdateSkillInput =
   | {
+      client: ClientKind;
+      resourceId: string;
       mode: "manual";
       targetId: string;
       manifest: string;
       installKind: SkillInstallInputKind;
     }
   | {
+      client: ClientKind;
+      resourceId: string;
       mode: "github";
       targetId: string;
       githubRepoUrl: string;
@@ -52,6 +61,13 @@ export interface CopySkillInput {
   targetId: string;
   manifest: string;
   installKind: SkillInstallInputKind;
+}
+
+export interface RemoveSkillInput {
+  resourceId: string;
+  client: ClientKind;
+  targetId: string;
+  sourcePath: string | null;
 }
 
 export interface GithubSkillDiscoveryResult {
@@ -82,7 +98,7 @@ interface UseSkillManagerResult {
   updateSkill: (input: UpdateSkillInput) => Promise<boolean>;
   copySkill: (input: CopySkillInput) => Promise<boolean>;
   discoverGithubSkills: (githubRepoUrl: string) => Promise<GithubSkillDiscoveryResult | null>;
-  removeSkill: (targetId: string, sourcePath: string | null) => Promise<boolean>;
+  removeSkill: (input: RemoveSkillInput) => Promise<boolean>;
   clearFeedback: () => void;
 }
 
@@ -96,16 +112,16 @@ function envelopeErrorDiagnostic(
   return runtimeErrorToDiagnostic(fallbackMessage);
 }
 
-function sortResources(resources: ResourceRecord[]): ResourceRecord[] {
-  return [...resources].sort((left, right) => {
-    if (left.display_name !== right.display_name) {
-      return left.display_name.localeCompare(right.display_name);
-    }
-    return left.id.localeCompare(right.id);
-  });
+function prefixWarning(client: ClientKind, warning: string): string {
+  const trimmed = warning.trim();
+  if (trimmed.length === 0) {
+    return "";
+  }
+
+  return `${formatClientLabel(client)}: ${trimmed}`;
 }
 
-export function useSkillManager(client: ClientKind | null): UseSkillManagerResult {
+export function useSkillManager(): UseSkillManagerResult {
   const [phase, setPhase] = useState<LoadPhase>("idle");
   const [resources, setResources] = useState<ResourceRecord[]>([]);
   const [warning, setWarning] = useState<string | null>(null);
@@ -116,44 +132,81 @@ export function useSkillManager(client: ClientKind | null): UseSkillManagerResul
   const [pendingCopyId, setPendingCopyId] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
-    if (client === null) {
-      setPhase("idle");
-      setResources([]);
-      setWarning(null);
-      setOperationError(null);
-      return;
-    }
-
     setPhase("loading");
     setOperationError(null);
 
     try {
-      const envelope = await listResources({
-        client,
-        resource_kind: "skill",
-      });
+      const results = await Promise.all(
+        SKILL_CLIENTS.map(async (client) => {
+          try {
+            const envelope = await listResources({
+              client,
+              resource_kind: "skill",
+            });
 
-      if (!envelope.ok || envelope.data === null) {
+            return { client, envelope, runtimeError: null as ErrorDiagnostic | null };
+          } catch (error) {
+            const message = error instanceof Error ? error.message : "Unknown list runtime error.";
+            return {
+              client,
+              envelope: null,
+              runtimeError: runtimeErrorToDiagnostic(message),
+            };
+          }
+        }),
+      );
+
+      const aggregatedResources: ResourceRecord[] = [];
+      const warnings: string[] = [];
+      const diagnostics: ErrorDiagnostic[] = [];
+
+      for (const result of results) {
+        if (result.runtimeError) {
+          diagnostics.push(result.runtimeError);
+          warnings.push(prefixWarning(result.client, result.runtimeError.message));
+          continue;
+        }
+
+        const envelope = result.envelope;
+        if (!envelope || !envelope.ok || envelope.data === null) {
+          const diagnostic = envelope
+            ? envelopeErrorDiagnostic(
+                envelope,
+                "List command failed without an explicit error payload.",
+              )
+            : runtimeErrorToDiagnostic("List command failed without an explicit error payload.");
+          diagnostics.push(diagnostic);
+          warnings.push(prefixWarning(result.client, diagnostic.message));
+          continue;
+        }
+
+        aggregatedResources.push(...envelope.data.items);
+        if (envelope.data.warning) {
+          const redactedWarning = redactNullableSensitiveText(envelope.data.warning);
+          warnings.push(prefixWarning(result.client, redactedWarning ?? envelope.data.warning));
+        }
+      }
+
+      if (aggregatedResources.length === 0 && diagnostics.length > 0) {
         setPhase("error");
-        setOperationError(
-          envelopeErrorDiagnostic(
-            envelope,
-            "List command failed without an explicit error payload.",
-          ),
-        );
+        setResources([]);
+        setWarning(null);
+        setOperationError(diagnostics[0]);
         return;
       }
 
-      setResources(sortResources(envelope.data.items));
-      setWarning(redactNullableSensitiveText(envelope.data.warning));
+      setResources(sortSkillResources(aggregatedResources));
+      setWarning(warnings.filter((entry) => entry.length > 0).join(" | ") || null);
       setOperationError(null);
       setPhase("ready");
     } catch (error) {
       setPhase("error");
+      setResources([]);
+      setWarning(null);
       const message = error instanceof Error ? error.message : "Unknown list runtime error.";
       setOperationError(runtimeErrorToDiagnostic(message));
     }
-  }, [client]);
+  }, []);
 
   useEffect(() => {
     void refresh();
@@ -161,16 +214,6 @@ export function useSkillManager(client: ClientKind | null): UseSkillManagerResul
 
   const addSkill = useCallback(
     async (input: AddSkillInput) => {
-      if (client === null) {
-        const diagnostic = runtimeErrorToDiagnostic("Select a client before adding a skill entry.");
-        setFeedback({
-          kind: "error",
-          message: diagnostic.message,
-          diagnostic,
-        });
-        return false;
-      }
-
       try {
         const payload: Record<string, unknown> =
           input.mode === "github"
@@ -185,7 +228,7 @@ export function useSkillManager(client: ClientKind | null): UseSkillManagerResul
               };
 
         const envelope = await mutateResource({
-          client,
+          client: input.destinationClient,
           resource_kind: "skill",
           action: "add",
           target_id: input.targetId,
@@ -215,7 +258,7 @@ export function useSkillManager(client: ClientKind | null): UseSkillManagerResul
         return false;
       }
     },
-    [client, refresh],
+    [refresh],
   );
 
   const discoverGithubSkills = useCallback(async (githubRepoUrl: string) => {
@@ -261,27 +304,15 @@ export function useSkillManager(client: ClientKind | null): UseSkillManagerResul
   }, []);
 
   const removeSkill = useCallback(
-    async (targetId: string, sourcePath: string | null) => {
-      if (client === null) {
-        const diagnostic = runtimeErrorToDiagnostic(
-          "Select a client before removing a skill entry.",
-        );
-        setFeedback({
-          kind: "error",
-          message: diagnostic.message,
-          diagnostic,
-        });
-        return false;
-      }
-
-      setPendingRemovalId(targetId);
+    async (input: RemoveSkillInput) => {
+      setPendingRemovalId(input.resourceId);
       try {
         const envelope = await mutateResource({
-          client,
+          client: input.client,
           resource_kind: "skill",
           action: "remove",
-          target_id: targetId,
-          payload: sourcePath ? { source_path: sourcePath } : null,
+          target_id: input.targetId,
+          payload: input.sourcePath ? { source_path: input.sourcePath } : null,
         });
 
         if (!envelope.ok || envelope.data === null) {
@@ -309,24 +340,12 @@ export function useSkillManager(client: ClientKind | null): UseSkillManagerResul
         setPendingRemovalId(null);
       }
     },
-    [client, refresh],
+    [refresh],
   );
 
   const updateSkill = useCallback(
     async (input: UpdateSkillInput) => {
-      if (client === null) {
-        const diagnostic = runtimeErrorToDiagnostic(
-          "Select a client before updating a skill entry.",
-        );
-        setFeedback({
-          kind: "error",
-          message: diagnostic.message,
-          diagnostic,
-        });
-        return false;
-      }
-
-      setPendingUpdateId(input.targetId);
+      setPendingUpdateId(input.resourceId);
       try {
         const payload: Record<string, unknown> =
           input.mode === "github"
@@ -341,7 +360,7 @@ export function useSkillManager(client: ClientKind | null): UseSkillManagerResul
               };
 
         const envelope = await mutateResource({
-          client,
+          client: input.client,
           resource_kind: "skill",
           action: "update",
           target_id: input.targetId,
@@ -373,35 +392,11 @@ export function useSkillManager(client: ClientKind | null): UseSkillManagerResul
         setPendingUpdateId(null);
       }
     },
-    [client, refresh],
+    [refresh],
   );
 
   const copySkill = useCallback(
     async (input: CopySkillInput) => {
-      if (client === null) {
-        const diagnostic = runtimeErrorToDiagnostic(
-          "Select a client before copying a skill entry.",
-        );
-        setFeedback({
-          kind: "error",
-          message: diagnostic.message,
-          diagnostic,
-        });
-        return false;
-      }
-
-      if (input.sourceClient !== client) {
-        const diagnostic = runtimeErrorToDiagnostic(
-          "Selected source client is stale. Reload the skills list and retry the copy operation.",
-        );
-        setFeedback({
-          kind: "error",
-          message: diagnostic.message,
-          diagnostic,
-        });
-        return false;
-      }
-
       if (input.destinationClient === input.sourceClient) {
         const diagnostic = runtimeErrorToDiagnostic(
           "Choose a different destination client when copying a skill entry.",
@@ -462,6 +457,7 @@ export function useSkillManager(client: ClientKind | null): UseSkillManagerResul
         }
 
         setFeedback({ kind: "success", message: redactSensitiveText(envelope.data.message) });
+        await refresh();
         return true;
       } catch (error) {
         const message = error instanceof Error ? error.message : "Unknown copy runtime error.";
@@ -476,7 +472,7 @@ export function useSkillManager(client: ClientKind | null): UseSkillManagerResul
         setPendingCopyId(null);
       }
     },
-    [client],
+    [refresh],
   );
 
   return {

--- a/tests/skill-context.test.ts
+++ b/tests/skill-context.test.ts
@@ -1,12 +1,46 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import type { ResourceRecord } from "../src/backend/contracts.ts";
 import { RESOURCE_KIND_CATALOG } from "../src/backend/contracts.ts";
 import { listNativeResourceEntryPoints } from "../src/features/skills/native-resource-catalog.ts";
+import { buildSkillContextHint } from "../src/features/skills/skill-context.ts";
 import {
-  buildSkillContextHint,
+  countSkillResourcesByClient,
+  filterSkillResources,
+  toggleSkillClientFilter,
+} from "../src/features/skills/skill-list-view.ts";
+import {
+  buildSkillCopyDestinationClients,
   describeSkillAction,
-} from "../src/features/skills/skill-context.ts";
+  SKILL_CLIENTS,
+} from "../src/features/skills/skill-targets.ts";
+
+function createSkillResource(
+  overrides: Partial<ResourceRecord> &
+    Pick<ResourceRecord, "id" | "client" | "display_name" | "install_kind">,
+): ResourceRecord {
+  return {
+    id: overrides.id,
+    logical_id: overrides.logical_id ?? overrides.display_name,
+    client: overrides.client,
+    display_name: overrides.display_name,
+    enabled: overrides.enabled ?? true,
+    transport_kind: null,
+    transport_command: null,
+    transport_args: null,
+    transport_url: null,
+    source_path: overrides.source_path ?? null,
+    source_id: overrides.source_id ?? `${overrides.client}::skills`,
+    source_scope: overrides.source_scope ?? "user",
+    source_label: overrides.source_label ?? "Personal skills directory",
+    is_effective: overrides.is_effective ?? true,
+    shadowed_by: overrides.shadowed_by ?? null,
+    description: overrides.description ?? null,
+    install_kind: overrides.install_kind,
+    manifest_content: overrides.manifest_content ?? null,
+  };
+}
 
 test("project mode hint stays explicit about personal-only skill storage", () => {
   assert.match(buildSkillContextHint("project"), /generic skill libraries/i);
@@ -16,16 +50,81 @@ test("project mode hint stays explicit about personal-only skill storage", () =>
 test("personal mode hint stays concise", () => {
   assert.equal(
     buildSkillContextHint("personal"),
-    "This tab manages AI Manager generic skill libraries for the selected client.",
+    "This tab manages AI Manager generic skill libraries across the supported clients.",
   );
 });
 
-test("skill action labels stay explicit", () => {
+test("skill action labels stay explicit and can target a client", () => {
   assert.equal(describeSkillAction("add"), "Add personal skill");
-  assert.equal(describeSkillAction("update"), "Update personal skill");
+  assert.equal(describeSkillAction("update", "cursor"), "Update Cursor personal skill");
   assert.equal(describeSkillAction("remove"), "Remove from personal");
   assert.equal(describeSkillAction("copy"), "Copy to another client");
-  assert.equal(describeSkillAction("import"), "Import to personal skills");
+  assert.equal(
+    describeSkillAction("import", "claude_code"),
+    "Import to Claude Code personal library",
+  );
+});
+
+test("skill client catalog excludes the source client for copy workflows", () => {
+  assert.deepEqual(SKILL_CLIENTS, ["claude_code", "cursor", "codex"]);
+  assert.deepEqual(buildSkillCopyDestinationClients("cursor"), ["claude_code", "codex"]);
+});
+
+test("skill list view filters by client and search query", () => {
+  const resources = [
+    createSkillResource({
+      id: "claude::writer",
+      client: "claude_code",
+      display_name: "writer",
+      install_kind: "directory",
+    }),
+    createSkillResource({
+      id: "cursor::lint",
+      client: "cursor",
+      display_name: "lint-helper",
+      install_kind: "file",
+    }),
+    createSkillResource({
+      id: "codex::tests",
+      client: "codex",
+      display_name: "test-runner",
+      install_kind: "directory",
+    }),
+  ];
+
+  assert.deepEqual(
+    filterSkillResources(resources, ["cursor", "codex"], "cursor").map((resource) => resource.id),
+    ["cursor::lint"],
+  );
+});
+
+test("skill list view counts resources per client and preserves a single active filter", () => {
+  const resources = [
+    createSkillResource({
+      id: "claude::writer",
+      client: "claude_code",
+      display_name: "writer",
+      install_kind: "directory",
+    }),
+    createSkillResource({
+      id: "cursor::lint",
+      client: "cursor",
+      display_name: "lint-helper",
+      install_kind: "file",
+    }),
+    createSkillResource({
+      id: "cursor::review",
+      client: "cursor",
+      display_name: "review-helper",
+      install_kind: "directory",
+    }),
+  ];
+
+  const counts = countSkillResourcesByClient(resources);
+  assert.equal(counts.get("claude_code"), 1);
+  assert.equal(counts.get("cursor"), 2);
+  assert.equal(counts.get("codex"), 0);
+  assert.deepEqual(toggleSkillClientFilter(["cursor"], "cursor"), ["cursor"]);
 });
 
 test("resource kind catalog marks generic and native families explicitly", () => {


### PR DESCRIPTION
## Summary
- move Skill Library client filtering into the panel so it matches MCP Manager’s interaction model
- aggregate generic skill listings across clients while keeping mutations explicitly targeted
- align the skill table, add flow, and route chrome with the MCP manager surface

Closes #145