### PR TITLE
refactor: remove redundant manager route overviews

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "package:macos:dmg": "node ./scripts/package-macos-dmg.mjs",
     "test": "pnpm run test:contracts && pnpm run test:web:unit",
     "test:contracts": "node --test tests/error-ui-contract.test.mjs tests/normalized-domain-model.test.mjs tests/support-matrix.test.mjs tests/mvp-acceptance-contract.test.mjs",
-    "test:web:unit": "tsx --test tests/resource-context.test.ts tests/mcp-targets.test.ts tests/mcp-replication.test.ts tests/skill-context.test.ts",
+    "test:web:unit": "tsx --test tests/resource-context.test.ts tests/mcp-targets.test.ts tests/mcp-replication.test.ts tests/skill-context.test.ts tests/route-overview.test.ts",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { formatClientLabel } from "./features/clients/client-labels";
 import { useClientDetections } from "./features/clients/useClientDetections";
 import { McpManagerPanel } from "./features/mcp/McpManagerPanel";
 import { type AppRoute, NAVIGATION_ITEMS } from "./features/navigation";
+import { buildRouteOverview } from "./features/navigation/route-overview";
 import { ResourceContextBar } from "./features/resources/ResourceContextBar";
 import {
   normalizeProjectRootInput,
@@ -85,6 +86,7 @@ function App() {
     [activeRoute, resourceContext],
   );
   const isDashboardRoute = activeRoute === "dashboard";
+  const routeOverview = useMemo(() => buildRouteOverview(activeRoute), [activeRoute]);
 
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_8%_2%,#f9f8f3_0%,#edf6ff_40%,#e9f0f4_100%)] p-4 text-slate-900 max-[720px]:p-3">
@@ -213,35 +215,13 @@ function App() {
                   />
                 ))}
               </section>
-            ) : activeRoute === "skills" ? (
+            ) : routeOverview ? (
               <section className="flex flex-wrap items-end justify-between gap-3 rounded-2xl border border-slate-200 bg-[linear-gradient(180deg,#fbfdff_0%,#f7fafc_100%)] px-4 py-3">
                 <div className="grid gap-1">
                   <p className="text-[0.7rem] font-semibold uppercase tracking-[0.09em] text-slate-500">
-                    Skill Library Overview
+                    {routeOverview.eyebrow}
                   </p>
-                  <p className="text-sm text-slate-700">
-                    Generic skill libraries now span the supported clients inside the selected
-                    context.
-                  </p>
-                </div>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setActiveRoute("dashboard")}
-                >
-                  Open Dashboard
-                </Button>
-              </section>
-            ) : (
-              <section className="flex flex-wrap items-end justify-between gap-3 rounded-2xl border border-slate-200 bg-[linear-gradient(180deg,#fbfdff_0%,#f7fafc_100%)] px-4 py-3">
-                <div className="grid gap-1">
-                  <p className="text-[0.7rem] font-semibold uppercase tracking-[0.09em] text-slate-500">
-                    MCP Overview
-                  </p>
-                  <p className="text-sm text-slate-700">
-                    MCP resources now span all supported clients inside the selected context.
-                  </p>
+                  <p className="text-sm text-slate-700">{routeOverview.description}</p>
                 </div>
 
                 <Button
@@ -253,7 +233,7 @@ function App() {
                   Open Dashboard
                 </Button>
               </section>
-            )}
+            ) : null}
 
             {!isDashboardRoute ? (
               <ResourceContextBar

--- a/src/features/navigation/route-overview.ts
+++ b/src/features/navigation/route-overview.ts
@@ -1,0 +1,15 @@
+import type { AppRoute } from "../navigation";
+
+export interface RouteOverviewContent {
+  eyebrow: string;
+  description: string;
+}
+
+export function buildRouteOverview(route: AppRoute): RouteOverviewContent | null {
+  switch (route) {
+    case "dashboard":
+    case "mcp":
+    case "skills":
+      return null;
+  }
+}

--- a/tests/route-overview.test.ts
+++ b/tests/route-overview.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildRouteOverview } from "../src/features/navigation/route-overview.ts";
+
+test("manager routes no longer render route-level overview chrome", () => {
+  assert.equal(buildRouteOverview("dashboard"), null);
+  assert.equal(buildRouteOverview("mcp"), null);
+  assert.equal(buildRouteOverview("skills"), null);
+});


### PR DESCRIPTION
## Summary
- remove the route-level Skill Library and MCP overview banners from the app shell
- keep the shared resource context bar and manager panels intact
- add a small route-overview unit test so the chrome stays opt-in

Closes #148