### PR TITLE
fix: constrain slide-over forms to the viewport

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "package:macos:dmg": "node ./scripts/package-macos-dmg.mjs",
     "test": "pnpm run test:contracts && pnpm run test:web:unit",
     "test:contracts": "node --test tests/error-ui-contract.test.mjs tests/normalized-domain-model.test.mjs tests/support-matrix.test.mjs tests/mvp-acceptance-contract.test.mjs",
-    "test:web:unit": "tsx --test tests/resource-context.test.ts tests/mcp-targets.test.ts tests/mcp-replication.test.ts tests/skill-context.test.ts tests/route-overview.test.ts tests/client-filter-selection.test.ts",
+    "test:web:unit": "tsx --test tests/resource-context.test.ts tests/mcp-targets.test.ts tests/mcp-replication.test.ts tests/skill-context.test.ts tests/route-overview.test.ts tests/client-filter-selection.test.ts tests/slide-over-scroll-lock.test.ts",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/src/components/shared/SlideOverPanel.tsx
+++ b/src/components/shared/SlideOverPanel.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useEffect } from "react";
 
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
+import { lockSlideOverBackgroundScroll } from "./slide-over-scroll-lock";
 
 interface SlideOverPanelProps {
   open: boolean;
@@ -25,6 +26,14 @@ export function SlideOverPanel({
       return;
     }
 
+    return lockSlideOverBackgroundScroll(document);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         onClose();
@@ -40,7 +49,7 @@ export function SlideOverPanel({
   }
 
   return (
-    <div className="fixed inset-0 z-40 bg-slate-900/24 backdrop-blur-[1px]">
+    <div className="fixed inset-0 z-40 overflow-hidden bg-slate-900/24 backdrop-blur-[1px]">
       <button
         type="button"
         aria-label="Close panel"
@@ -52,7 +61,7 @@ export function SlideOverPanel({
         aria-modal="true"
         aria-label={title}
         className={cn(
-          "absolute inset-y-0 right-0 z-10 flex h-full min-h-0 w-full max-w-[28.5rem] flex-col border-l border-slate-200 bg-white/95 p-5 shadow-[0_24px_60px_rgba(15,23,42,0.24)] backdrop-blur",
+          "absolute inset-y-0 right-0 z-10 flex h-[100dvh] max-h-[100dvh] min-h-0 w-full max-w-[28.5rem] flex-col border-l border-slate-200 bg-white/95 p-5 shadow-[0_24px_60px_rgba(15,23,42,0.24)] backdrop-blur",
           "max-[640px]:max-w-full max-[640px]:p-4",
           panelClassName,
         )}
@@ -69,7 +78,7 @@ export function SlideOverPanel({
           </Button>
         </header>
 
-        <div className="mt-4 min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto pb-8">
+        <div className="mt-4 min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain pb-8">
           {children}
         </div>
       </section>

--- a/src/components/shared/slide-over-scroll-lock.ts
+++ b/src/components/shared/slide-over-scroll-lock.ts
@@ -1,0 +1,32 @@
+interface ScrollStyleTarget {
+  overflow: string;
+  overscrollBehavior: string;
+}
+
+interface ScrollLockTarget {
+  body: {
+    style: ScrollStyleTarget;
+  };
+  documentElement: {
+    style: ScrollStyleTarget;
+  };
+}
+
+export function lockSlideOverBackgroundScroll(target: ScrollLockTarget): () => void {
+  const previousBodyOverflow = target.body.style.overflow;
+  const previousBodyOverscrollBehavior = target.body.style.overscrollBehavior;
+  const previousRootOverflow = target.documentElement.style.overflow;
+  const previousRootOverscrollBehavior = target.documentElement.style.overscrollBehavior;
+
+  target.body.style.overflow = "hidden";
+  target.body.style.overscrollBehavior = "none";
+  target.documentElement.style.overflow = "hidden";
+  target.documentElement.style.overscrollBehavior = "none";
+
+  return () => {
+    target.body.style.overflow = previousBodyOverflow;
+    target.body.style.overscrollBehavior = previousBodyOverscrollBehavior;
+    target.documentElement.style.overflow = previousRootOverflow;
+    target.documentElement.style.overscrollBehavior = previousRootOverscrollBehavior;
+  };
+}

--- a/tests/slide-over-scroll-lock.test.ts
+++ b/tests/slide-over-scroll-lock.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { lockSlideOverBackgroundScroll } from "../src/components/shared/slide-over-scroll-lock.ts";
+
+test("slide-over scroll lock hides background scrolling until restored", () => {
+  const target = {
+    body: {
+      style: {
+        overflow: "auto",
+        overscrollBehavior: "contain",
+      },
+    },
+    documentElement: {
+      style: {
+        overflow: "clip",
+        overscrollBehavior: "auto",
+      },
+    },
+  };
+
+  const restore = lockSlideOverBackgroundScroll(target);
+
+  assert.deepEqual(target, {
+    body: {
+      style: {
+        overflow: "hidden",
+        overscrollBehavior: "none",
+      },
+    },
+    documentElement: {
+      style: {
+        overflow: "hidden",
+        overscrollBehavior: "none",
+      },
+    },
+  });
+
+  restore();
+
+  assert.deepEqual(target, {
+    body: {
+      style: {
+        overflow: "auto",
+        overscrollBehavior: "contain",
+      },
+    },
+    documentElement: {
+      style: {
+        overflow: "clip",
+        overscrollBehavior: "auto",
+      },
+    },
+  });
+});


### PR DESCRIPTION
## Summary
- cap the slide-over panel to the live viewport height so long add forms use a single scroll container
- lock background page scrolling while any slide-over is open
- add unit coverage for the scroll lock helper that restores document styles

Closes #152