### PR TITLE
fix: portal slide-over panels to the document body

### DIFF
--- a/src/components/shared/SlideOverPanel.tsx
+++ b/src/components/shared/SlideOverPanel.tsx
@@ -1,7 +1,9 @@
 import { type ReactNode, useEffect } from "react";
+import { createPortal } from "react-dom";
 
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
+import { resolveSlideOverPortalTarget } from "./slide-over-portal-target";
 import { lockSlideOverBackgroundScroll } from "./slide-over-scroll-lock";
 
 interface SlideOverPanelProps {
@@ -48,7 +50,14 @@ export function SlideOverPanel({
     return null;
   }
 
-  return (
+  const portalTarget = resolveSlideOverPortalTarget(
+    typeof document === "undefined" ? null : document,
+  );
+  if (portalTarget === null) {
+    return null;
+  }
+
+  return createPortal(
     <div className="fixed inset-0 z-40 overflow-hidden bg-slate-900/24 backdrop-blur-[1px]">
       <button
         type="button"
@@ -82,6 +91,7 @@ export function SlideOverPanel({
           {children}
         </div>
       </section>
-    </div>
+    </div>,
+    portalTarget,
   );
 }

--- a/src/components/shared/slide-over-portal-target.ts
+++ b/src/components/shared/slide-over-portal-target.ts
@@ -1,0 +1,9 @@
+export interface SlideOverPortalDocument {
+  body: HTMLElement;
+}
+
+export function resolveSlideOverPortalTarget(
+  target: SlideOverPortalDocument | null,
+): HTMLElement | null {
+  return target?.body ?? null;
+}

--- a/tests/slide-over-scroll-lock.test.ts
+++ b/tests/slide-over-scroll-lock.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { resolveSlideOverPortalTarget } from "../src/components/shared/slide-over-portal-target.ts";
 import { lockSlideOverBackgroundScroll } from "../src/components/shared/slide-over-scroll-lock.ts";
 
 test("slide-over scroll lock hides background scrolling until restored", () => {
@@ -52,4 +53,11 @@ test("slide-over scroll lock hides background scrolling until restored", () => {
       },
     },
   });
+});
+
+test("slide-over portal target resolves to document body", () => {
+  const body = {} as HTMLElement;
+
+  assert.equal(resolveSlideOverPortalTarget({ body }), body);
+  assert.equal(resolveSlideOverPortalTarget(null), null);
 });


### PR DESCRIPTION
## Summary
- render slide-over panels through a portal attached to document.body
- keep viewport anchoring stable even when the parent layout uses backdrop blur and the page is scrolled
- add a small regression test for the portal mount target helper

Closes #156